### PR TITLE
Write to PRTFile

### DIFF
--- a/inc/IHOP.h
+++ b/inc/IHOP.h
@@ -21,14 +21,14 @@
 !     IHOP parameters
 !     ===============
 !--   COMMON /IHOP_PARAMS_L/ IHOP logical-type parameters:
-!     IHOP_bellOn   :: true if bellhop driver needs to run (UNUSED)
+!     writeDelay    :: true if delay is a desired output 
 !     useSSPFile    :: true if *.ssp is used instead MITgcm SSP
 
-      LOGICAL IHOP_bellOn
+      LOGICAL writeDelay
       LOGICAL useSSPFile
 
       COMMON /IHOP_PARAMS_L/                                                                                                             &
-     &      IHOP_bellOn, useSSPFile
+     &      writeDelay, useSSPFile
 
 !-- COMMON /IHOP_PARAMS_C/ IHOP Character-type parameters:
 !   IHOP_fileroot   :: File name for reading in an environment

--- a/mitgcm_code/IHOP_SIZE.h
+++ b/mitgcm_code/IHOP_SIZE.h
@@ -17,7 +17,7 @@
 !     ================================
       INTEGER nts
 #ifdef IHOP_MULTIPLE_TIMES
-      PARAMETER ( nts=721 )
+      PARAMETER ( nts=1080 )
 #else 
       PARAMETER ( nts=1 )
 #endif

--- a/mitgcm_code/cal.h
+++ b/mitgcm_code/cal.h
@@ -1,0 +1,131 @@
+!     ==================================================================
+!     HEADER calendar
+!     ==================================================================
+!
+!     o This header file contains variables that are used by the
+!       calendar tool. The calendar tool can be used in the ECCO
+!       SEALION release of the MITgcmUV.
+!
+!     started: Christian Eckert eckert@mit.edu  30-Jun-1999
+!     changed: Christian Eckert eckert@mit.edu  17-Dec-1999
+!              - restructured the original version in order to have a
+!                better interface to the MITgcmUV.
+!
+!     ==================================================================
+!     HEADER calendar
+!     ==================================================================
+
+!   - Parameters of the numerical model:
+!
+!     modelStart       :: start time of the numerical model.
+!     modelStartDate   :: start date of the numerical model.
+!     modelEnd         :: end   time of the numerical model.
+!     modelEndDate     :: end   date of the numerical model.
+!     modelStep        :: timestep of the numerical model.
+!     modelIntSteps    :: number of timestep that are to be performed.
+!     modelIter0       :: the numerical models initial timestep number.
+!     modelIterEnd     :: the models last timestep number.
+!     modelStepsperday :: number of model time steps per day (<- removed).
+
+!   - Parameters used by the calendar:
+!
+!     refDate          :: first day of the Gregorian Calendar.
+!     nMonthYear       :: number months in a year.
+!     nDayMonth        :: days per month depending on the year being a leap
+!                         year or not. If the Model calendar is used a 360
+!                         days year with 30 days months is used instead.
+!     nDaysNoLeap      :: number of days in a usual year.
+!     nDaysLeap        :: number of days in a leap year.
+!     nMaxDayMonth     :: maximum number of days in a years month.
+!     hoursPerDay      :: number of hours   in a calendars day.
+!     minutesPerDay    :: number of minutes in a calendars day.
+!     minutesPerHour   :: number of minutes in a calendars hour.
+!     secondsPerDay    :: number of seconds in a calendars day.
+!     secondsPerHour   :: number of seconds in a calendars hour.
+!     secondsPerMinute :: number of seconds in a calendars minute.
+!     cal_setStatus    :: status of calendar parms setting (0=none, 3=fully set)
+
+      INTEGER nMonthYear
+      PARAMETER ( nMonthYear = 12 )
+
+      COMMON /CALENDAR_RL/                                                                                                              &
+     &                modelStart,                                                                                                       &
+     &                modelEnd,                                                                                                         &
+     &                modelStep
+      _RL modelStart
+      _RL modelEnd
+      _RL modelStep
+
+      COMMON /CALENDAR_I/                                                                                                               &
+     &               refDate,                                                                                                           &
+     &               nDayMonth,                                                                                                         &
+     &               nDaysNoLeap,                                                                                                       &
+     &               nDaysLeap,                                                                                                         &
+     &               nMaxDayMonth,                                                                                                      &
+     &               hoursPerDay,                                                                                                       &
+     &               minutesPerDay,                                                                                                     &
+     &               minutesPerHour,                                                                                                    &
+     &               secondsPerDay,                                                                                                     &
+     &               secondsPerHour,                                                                                                    &
+     &               secondsPerMinute,                                                                                                  &
+     &               modelStartDate,                                                                                                    &
+     &               modelEndDate,                                                                                                      &
+     &               modelIter0,                                                                                                        &
+     &               modelIterEnd,                                                                                                      &
+     &               modelIntSteps,                                                                                                     &
+     &               cal_setStatus,                                                                                                     &
+     &               startdate_1,                                                                                                       &
+     &               startdate_2
+
+      INTEGER refDate(4)
+      INTEGER nDayMonth(nMonthYear,2)
+      INTEGER nDaysNoLeap
+      INTEGER nDaysLeap
+      INTEGER nMaxDayMonth
+      INTEGER hoursPerDay
+      INTEGER minutesPerDay
+      INTEGER minutesPerHour
+      INTEGER secondsPerDay
+      INTEGER secondsPerHour
+      INTEGER secondsPerMinute
+
+      INTEGER modelStartDate(4)
+      INTEGER modelEndDate(4)
+      INTEGER modelIter0
+      INTEGER modelIterEnd
+      INTEGER modelIntSteps
+
+      INTEGER cal_setStatus
+      INTEGER startdate_1
+      INTEGER startdate_2
+
+!   calendarDumps :: When set, approximate months (30-31 days) and years (360-372 days)
+!                    for parameters chkPtFreq, pChkPtFreq, taveFreq, SEAICE_taveFreq,
+!                    KPP_taveFreq, and freq in pkg/diagnostics are converted to exact
+!                    calendar months and years.  Requires pkg/cal.
+      COMMON /CALENDAR_L/                                                                                                               &
+     &               calendarDumps,                                                                                                     &
+     &               usingModelCalendar,                                                                                                &
+     &               usingNoLeapYearCal,                                                                                                &
+     &               usingJulianCalendar,                                                                                               &
+     &               usingGregorianCalendar
+      LOGICAL calendarDumps
+      LOGICAL usingModelCalendar
+      LOGICAL usingNoLeapYearCal
+      LOGICAL usingJulianCalendar
+      LOGICAL usingGregorianCalendar
+
+!     theCalendar :: type of calendar to use; available:
+!                    'model', 'gregorian' or 'noLeapYear'.
+!     dayOfWeek   :: Week day number one is the week day of refDate.
+!                    For the Gregorian calendar this is Friday, 15-Oct-1582.
+!     monthOfYear :: Both available calendars are assumed to have twelve
+!                    months.
+      COMMON /CALENDAR_C/                                                                                                               &
+     &                     theCalendar,                                                                                                 &
+     &                     dayOfWeek,                                                                                                   &
+     &                     monthOfYear
+      CHARACTER*(20) theCalendar
+      CHARACTER*(3) dayOfWeek(7)
+      CHARACTER*(3) monthOfYear(nMonthYear)
+

--- a/src/angle_mod.F90
+++ b/src/angle_mod.F90
@@ -117,7 +117,7 @@ CONTAINS
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
     IF ( Angles%Nalpha >= 1 ) THEN
-        WRITE(msgBuf,'(10F12.6)') Angles%alpha( 1:MIN(Angles%Nalpha,Number_to_Echo) )
+        WRITE(msgBuf,'(10F12.3)') Angles%alpha( 1:MIN(Angles%Nalpha,Number_to_Echo) )
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
     IF ( Angles%Nalpha > Number_to_Echo ) THEN

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -301,7 +301,7 @@ CONTAINS
     CASE ( 'A', 'a' )       ! arrivals calculation
        CLOSE( ARRFile )
        CLOSE( RAYFile )
-       CLOSE( DELFile )
+       IF ( writeDelay ) CLOSE( DELFile )
     CASE ( 'R', 'E' )       ! ray and eigen ray trace
        CLOSE( RAYFile )
     END SELECT
@@ -519,7 +519,7 @@ CONTAINS
                 CALL WriteRay2D( SrcDeclAngle, Beam%Nsteps )
              ELSE ! Compute the contribution to the field
                 CALL WriteRay2D( SrcDeclAngle, Beam%Nsteps )
-                CALL WriteDel2D( SrcDeclAngle, Beam%Nsteps )
+                IF (writeDelay) CALL WriteDel2D( SrcDeclAngle, Beam%Nsteps )
                 
                 SELECT CASE ( Beam%Type( 1 : 1 ) )
                 CASE ( 'g' )

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -306,7 +306,15 @@ CONTAINS
        CLOSE( RAYFile )
     END SELECT
   
-    CLOSE( PRTFile )
+    if (numberOfProcs.gt.1) then
+        if(myProcId.ne.(numberOfProcs-1)) then
+            CLOSE(PRTFile, STATUS='DELETE')
+        else
+            CLOSE(PRTFile)
+        endif
+    else
+        CLOSE(PRTFile)
+    endif
 #endif /* IHOP_WRITE_OUT */
   
   RETURN

--- a/src/ihop_readparms.F
+++ b/src/ihop_readparms.F
@@ -66,6 +66,7 @@ C     iUnit      :: Work variable for IO unit number
      &      IHOP_step
 
       NAMELIST /IHOP_PARM03/
+     &      writeDelay, 
      &      useSSPFile,
      &      IHOP_interpfile,
      &      ihop_iter,
@@ -233,6 +234,7 @@ C     Check paramters of IHOP_PARM02
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 C--   Default values for IHOP_PARM03 some are populated in
 C     ihop_init_fixed.f
+      writeDelay        = .TRUE.
       useSSPFile        = .FALSE.
       IHOP_interpfile   = ''
       DO i=1,nts

--- a/src/readenvihop.F90
+++ b/src/readenvihop.F90
@@ -1024,20 +1024,22 @@ CONTAINS
        WRITE( RAYFile, * ) '''rz'''
 # endif /* IHOP_THREED */
 
-       OPEN ( FILE = TRIM( fullName ) // '.delay', UNIT = DELFile, &
-              FORM = 'FORMATTED' )
-       WRITE( DELFile, * ) '''', Title( 1 : 50 ), ''''
-       WRITE( DELFile, * ) IHOP_freq
-       WRITE( DELFile, * ) Pos%NSx, Pos%NSy, Pos%NSz
-       WRITE( DELFile, * ) Angles%Nalpha, Angles%Nbeta
-       WRITE( DELFile, * ) Bdry%Top%HS%Depth
-       WRITE( DELFile, * ) Bdry%Bot%HS%Depth
+       IF (writeDelay) THEN
+        OPEN ( FILE = TRIM( fullName ) // '.delay', UNIT = DELFile, &
+               FORM = 'FORMATTED' )
+        WRITE( DELFile, * ) '''', Title( 1 : 50 ), ''''
+        WRITE( DELFile, * ) IHOP_freq
+        WRITE( DELFile, * ) Pos%NSx, Pos%NSy, Pos%NSz
+        WRITE( DELFile, * ) Angles%Nalpha, Angles%Nbeta
+        WRITE( DELFile, * ) Bdry%Top%HS%Depth
+        WRITE( DELFile, * ) Bdry%Bot%HS%Depth
 
 #ifdef IHOP_THREED
-       WRITE( DELFile, * ) '''xyz'''
+        WRITE( DELFile, * ) '''xyz'''
 # else /* IHOP_THREED */
-       WRITE( DELFile, * ) '''rz'''
+        WRITE( DELFile, * ) '''rz'''
 # endif /* IHOP_THREED */
+       ENDIF
 #endif /* IHOP_WRITE_OUT */
     CASE ( 'a' )        ! arrival file in binary format
 #ifdef IHOP_WRITE_OUT

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -17,6 +17,8 @@ MODULE writeRay
   USE ssp_mod,  only: Bdry
 
   IMPLICIT NONE
+!   == Global variables ==
+
   PRIVATE
 
 ! public interfaces
@@ -92,7 +94,7 @@ CONTAINS
        END IF
     END DO Stepping
 
-    ! write to ray file
+    ! write to delay file
 
 #ifdef IHOP_WRITE_OUT
     WRITE( DELFile, * ) alpha0


### PR DESCRIPTION
**ihop** uses an ascii file to write out summary level standard output. This file is defined as the PRTFile. 


Added calendar info for runs using **data.cal** and included an option to suppress writing delay information to an ASCII file. 