### PR TITLE
Eigenray data storage

### DIFF
--- a/mitgcm_input/data.ihop
+++ b/mitgcm_input/data.ihop
@@ -2,7 +2,7 @@
 # IHOP package parameters
 # ***********************
  &IHOP_PARM01 
- IHOP_fileroot='baro',
+ IHOP_fileroot='baroA',
  IHOP_title='baroclinic_gyre+ihop',
  &
 
@@ -19,12 +19,12 @@
 # rr + ihop_step < ihop_ranges(end)
  IHOP_rr=2542.0,
 
- IHOP_runopt='A',
+ IHOP_runopt='e',
  IHOP_nalpha=4,
  IHOP_alpha=-20.0, 20.0,
  &
 
  &IHOP_PARM03
  IHOP_interpfile = 'bc-gyre_ihop-grid.nc',
- ihop_iter = 1,2,3,4,5,6,7,8,9,
+ ihop_iter = 1,2,3,4,5,6,7,8,
  &

--- a/src/readenvihop.F90
+++ b/src/readenvihop.F90
@@ -982,6 +982,7 @@ CONTAINS
 #else /* IHOP_THREED */
        WRITE( RAYFile, * ) '''rz'''
 #endif /* IHOP_THREED */
+       FLUSH( RAYFile )
 #endif /* IHOP_WRITE_OUT */
     CASE ( 'e' )        ! eigenrays + arrival file in ascii format
 #ifdef IHOP_WRITE_OUT
@@ -1044,6 +1045,10 @@ CONTAINS
         WRITE( DELFile, * ) '''rz'''
 # endif /* IHOP_THREED */
        ENDIF
+
+       FLUSH( RAYFile )
+       IF (writeDelay) FLUSH( DELFile )
+       FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
     CASE ( 'A' )        ! arrival file in ascii format
 #ifdef IHOP_WRITE_OUT
@@ -1071,6 +1076,7 @@ CONTAINS
 # ifdef IHOP_THREED
        WRITE( ARRFile, * ) Pos%Ntheta, Pos%theta( 1 : Pos%Ntheta )
 # endif /* IHOP_THREED */
+       FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
     CASE ( 'a' )        ! arrival file in binary format
 #ifdef IHOP_WRITE_OUT
@@ -1100,8 +1106,8 @@ CONTAINS
 # ifdef IHOP_THREED
        WRITE( ARRFile    ) Pos%Ntheta, Pos%theta( 1 : Pos%Ntheta )
 # endif /* IHOP_THREED */
+       FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
-
     CASE DEFAULT
        atten = 0.0
 

--- a/src/readenvihop.F90
+++ b/src/readenvihop.F90
@@ -1363,7 +1363,7 @@ CONTAINS
         ray2D(iStep)%c = zeroRL
         ray2D(iStep)%Amp = zeroRL
         ray2D(iStep)%Phase = zeroRL
-        ray2D(iStep)%tau = (zeroRL, zeroRl)
+        ray2D(iStep)%tau = (zeroRL, zeroRL)
     END DO
 
   END ! SUBROUTINE resetMemory

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -28,7 +28,7 @@ MODULE writeRay
 
 !=======================================================================
 
-  INTEGER, PRIVATE :: MaxNRayPoints = 500000   ! this is the maximum length of 
+  INTEGER, PRIVATE :: MaxNRayPoints = 50000   ! this is the maximum length of 
   ! the ray vector that is written out
   INTEGER, PRIVATE :: is, N2, iSkip
 
@@ -91,6 +91,7 @@ CONTAINS
             MOD( is, iSkip ) == 0 .OR. is == Nsteps1 ) THEN
           N2 = N2 + 1
           ray2D( N2 )%x = ray2D( is )%x
+          ray2D( N2 )%tau = ray2D( is )%tau
        END IF
     END DO Stepping
 

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -58,6 +58,7 @@ CONTAINS
 
     ! write to ray file
 
+    WRITE(*, '(A,G,3I)') "Escobar:",alpha0, N2, ray2D(N2)%NumTopBnc, ray2D(N2)%NumBotBnc
 #ifdef IHOP_WRITE_OUT
     WRITE( RAYFile, '(G)') alpha0
     WRITE( RAYFile, '(3I)' ) N2, ray2D( Nsteps1 )%NumTopBnc, &

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -59,12 +59,12 @@ CONTAINS
     ! write to ray file
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( RAYFile, * ) alpha0
-    WRITE( RAYFile, * ) N2, ray2D( Nsteps1 )%NumTopBnc, &
+    WRITE( RAYFile, '(G)') alpha0
+    WRITE( RAYFile, '(3I)' ) N2, ray2D( Nsteps1 )%NumTopBnc, &
                         ray2D( Nsteps1 )%NumBotBnc
 
     DO is = 1, N2
-       WRITE( RAYFile, * ) ray2D( is )%x
+       WRITE( RAYFile, '(2G)' ) ray2D( is )%x
     END DO
 #endif /* IHOP_WRITE_OUT */
 
@@ -98,12 +98,12 @@ CONTAINS
     ! write to delay file
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( DELFile, * ) alpha0
-    WRITE( DELFile, * ) N2, ray2D( Nsteps1 )%NumTopBnc, &
+    WRITE( DELFile, '(G)' ) alpha0
+    WRITE( DELFile, '(3I)' ) N2, ray2D( Nsteps1 )%NumTopBnc, &
                         ray2D( Nsteps1 )%NumBotBnc
 
     DO is = 1, N2
-       WRITE( DELFile, * ) REAL(ray2D( is )%tau), ray2D( is )%x(2)
+       WRITE( DELFile, '(2G)' ) REAL(ray2D( is )%tau), ray2D( is )%x(2)
     END DO
 #endif /* IHOP_WRITE_OUT */
 


### PR DESCRIPTION
Reducing memory footprint of ihop diagnostics by only writing out eigenrays and arrival files. 

Fixed bug with large ASCII files, printing nonsense on ray2D output. `FLUSH`ed files after writing the header and reset values of ray2D to zeros at each ihop instance via the `resetMemory` s/r