### PR TITLE
Mpi cost for times of arrival

### DIFF
--- a/src/arr_mod.F90
+++ b/src/arr_mod.F90
@@ -22,7 +22,8 @@ MODULE arr_mod
 ! public interfaces
 !=======================================================================
 
-    public WriteArrivalsASCII, WriteArrivalsBinary, MaxNArr, NArr, Arr, AddArr 
+    public WriteArrivalsASCII, WriteArrivalsBinary, &
+           MaxNArr, NArr, Arr, AddArr, U
 #ifdef IHOP_THREED
     public NArr3D, Arr3D
 #endif /* IHOP_THREED */
@@ -31,6 +32,7 @@ MODULE arr_mod
 
   INTEGER               :: MaxNArr
   INTEGER, ALLOCATABLE  :: NArr( :, : )
+  COMPLEX, ALLOCATABLE  :: U( :, : )
 #ifdef IHOP_THREED
   INTEGER, ALLOCATABLE  :: NArr3D( :, :, : )
 #endif /* IHOP_THREED */

--- a/src/bdry_mod.F90
+++ b/src/bdry_mod.F90
@@ -71,7 +71,7 @@ MODULE bdry_mod
    TYPE(BdryPt), ALLOCATABLE :: Top( : ), Bot( : )
 
 CONTAINS
-  SUBROUTINE ReadATI( FileRoot, TopATI, DepthT, myThid ) 
+  SUBROUTINE ReadATI( TopATI, DepthT, myThid ) 
     ! Reads in the top altimetry
 
   !     == Routine Arguments ==
@@ -84,7 +84,6 @@ CONTAINS
     CHARACTER (LEN= 1), INTENT( IN ) :: TopATI
     REAL (KIND=_RL90),  INTENT( IN ) :: DepthT
     REAL (KIND=_RL90),  ALLOCATABLE  :: phi( : )
-    CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
 
     SELECT CASE ( TopATI )
     CASE ( '~', '*' )
@@ -98,11 +97,11 @@ CONTAINS
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
-       OPEN( UNIT = ATIFile,   FILE = TRIM( FileRoot ) // '.ati', &
+       OPEN( UNIT = ATIFile,   FILE = TRIM( IHOP_fileroot ) // '.ati', &
              STATUS = 'OLD', IOSTAT = IOStat, ACTION = 'READ' )
         IF ( IOsTAT /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(A)') 'ATIFile = ', TRIM( FileRoot ) // '.ati'
+            WRITE(msgBuf,'(A)') 'ATIFile = ', TRIM( IHOP_fileroot ) // '.ati'
             CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
             WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                 'Unable to open altimetry file'
@@ -234,7 +233,7 @@ CONTAINS
 
   ! **********************************************************************!
 
-SUBROUTINE ReadBTY( FileRoot, BotBTY, DepthB, myThid )
+SUBROUTINE ReadBTY( BotBTY, DepthB, myThid )
    ! Reads in the bottom bathymetry
 
    !     == Routine Arguments ==
@@ -246,7 +245,6 @@ SUBROUTINE ReadBTY( FileRoot, BotBTY, DepthB, myThid )
    !     == Local Variables ==
       CHARACTER (LEN= 1), INTENT( IN ) :: BotBTY
       REAL (KIND=_RL90),  INTENT( IN ) :: DepthB
-      CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
       INTEGER :: i,j,bi,bj
       LOGICAL :: firstnonzero
       REAL (KIND=_RL90) :: gcmbathy(sNx,sNy), gcmmin, gcmmax
@@ -266,11 +264,11 @@ SUBROUTINE ReadBTY( FileRoot, BotBTY, DepthB, myThid )
         ENDIF
 # endif /* IHOP_WRITE_OUT */
 
-         OPEN( UNIT = BTYFile, FILE = TRIM( FileRoot ) // '.bty', &
+         OPEN( UNIT = BTYFile, FILE = TRIM( IHOP_fileroot ) // '.bty', &
                STATUS = 'OLD', IOSTAT = IOStat, ACTION = 'READ' )
          IF ( IOSTAT /= 0 ) THEN
 # ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(A)') 'BTYFile = ', TRIM( FileRoot ) // '.bty'
+            WRITE(msgBuf,'(A)') 'BTYFile = ', TRIM( IHOP_fileroot ) // '.bty'
             ! In adjoint mode we do not write output besides on the first run
             IF (IHOP_dumpfreq.GE.0) &
                 CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )

--- a/src/bdry_mod.F90
+++ b/src/bdry_mod.F90
@@ -13,7 +13,7 @@ MODULE bdry_mod
    USE monotonic_mod,   only: monotonic
    USE ihop_mod,        only: PRTFile, ATIFile, BTYFile
    USE ssp_mod,         only: betaPowerLaw, ft
-  USE atten_mod,        only: CRCI
+   USE atten_mod,       only: CRCI
 
   IMPLICIT NONE
 ! == Global variables ==
@@ -86,7 +86,8 @@ CONTAINS
     CHARACTER (LEN= 1), INTENT( IN ) :: TopATI
     INTEGER :: iSeg
     REAL (KIND=_RL90),  INTENT( IN ) :: DepthT
-    REAL (KIND=_RL90),  ALLOCATABLE  :: phi( : )
+    REAL (KIND=_RL90),  ALLOCATABLE  :: phi(:)
+    REAL (KIND=_RL90),  ALLOCATABLE  :: x(:) 
 
     SELECT CASE ( TopATI )
     CASE ( '~', '*' )
@@ -222,7 +223,10 @@ CONTAINS
 
     CALL ComputeBdryTangentNormal( Top, 'Top' )
 
-    IF ( .NOT. monotonic( Top%x( 1 ), NAtiPts ) ) THEN
+    IF ( ALLOCATED(x) ) DEALLOCATE(x)
+    ALLOCATE( x(NAtiPts) )
+    x = Top%x(1)
+    IF ( .NOT. monotonic( x, NAtiPts ) ) THEN
 #ifdef IHOP_WRITE_OUT
         WRITE(msgBuf,'(2A)') 'BDRYMOD initATI', &
                         'Altimetry ranges are not monotonically increasing'
@@ -265,6 +269,7 @@ SUBROUTINE initBTY( BotBTY, DepthB, myThid )
       INTEGER :: i,j,bi,bj,iSeg
       LOGICAL :: firstnonzero
       REAL (KIND=_RL90) :: gcmbathy(sNx,sNy), gcmmin, gcmmax
+      REAL (KIND=_RL90), ALLOCATABLE :: x(:) 
 
       SELECT CASE ( BotBTY )
       CASE ( '~', '*' )
@@ -481,7 +486,10 @@ SUBROUTINE initBTY( BotBTY, DepthB, myThid )
 
    CALL ComputeBdryTangentNormal( Bot, 'Bot' )
 
-   IF ( .NOT. monotonic( Bot%x( 1 ), NBtyPts ) ) THEN
+   IF ( ALLOCATED(x) ) DEALLOCATE(x)
+   ALLOCATE( x(NBtyPts) )
+   x = Bot%x(1)
+   IF ( .NOT. monotonic( x, NBtyPts ) ) THEN
 # ifdef IHOP_WRITE_OUT
       WRITE(msgBuf,'(2A)') 'BDRYMOD initBTY: ', &
          'Bathymetry ranges are not monotonically increasing'

--- a/src/ihop_ad_diff.F90list
+++ b/src/ihop_ad_diff.F90list
@@ -9,7 +9,7 @@ influence.f90
 monotonic_mod.f90
 pchip_mod.f90
 poly_mod.f90
-readenvihop.f90
+initenvihop.f90
 refcoef.f90
 sort_mod.f90
 splinec_mod.f90

--- a/src/initenvihop.F90
+++ b/src/initenvihop.F90
@@ -1,7 +1,7 @@
 #include "IHOP_OPTIONS.h"
 !BOP
 ! !INTERFACE:
-MODULE readEnviHop
+MODULE initenvihop
 ! <CONTACT EMAIL="ivana@utexas.edu">
 !   Ivana Escobar
 ! </CONTACT>
@@ -35,11 +35,11 @@ MODULE readEnviHop
 
 !   == Public Interfaces ==
 !=======================================================================
-  public    ReadEnvironment, OpenOutputFiles, resetMemory
+  public    initEnv, OpenOutputFiles, resetMemory
 !=======================================================================
 
 CONTAINS
-  SUBROUTINE ReadEnvironment( myTime, myIter, myThid )
+  SUBROUTINE initEnv( myTime, myIter, myThid )
 
     ! I/O routine for acoustic fixed inputS
 
@@ -132,11 +132,11 @@ CONTAINS
         CASE( ' ' )
         CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+            WRITE(msgBuf,'(2A)') 'INITENVIHOP initEnv: ', & 
                              'Unknown bottom option letter in second position'
             CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-            STOP 'ABNORMAL END: S/R ReadEnvironment'
+            STOP 'ABNORMAL END: S/R initEnv'
         END SELECT
     ENDIF
 
@@ -198,10 +198,10 @@ CONTAINS
 
     ! Limits for tracing beams
 #ifdef IHOP_THREED
-    WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+    WRITE(msgBuf,'(2A)') 'INITENVIHOP initEnv: ', & 
                          '3D not supported in ihop'
     CALL PRINT_ERROR( msgBuf,myThid )
-    STOP 'ABNORMAL END: S/R ReadEnvironment'
+    STOP 'ABNORMAL END: S/R initEnv'
     !READ(  ENVFile, * ) Beam%deltas, Beam%Box%x, Beam%Box%y, Beam%Box%z
     Beam%Box%x = 1000.0 * Beam%Box%x   ! convert km to m
     Beam%Box%y = 1000.0 * Beam%Box%y   ! convert km to m
@@ -378,11 +378,11 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-                WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+                WRITE(msgBuf,'(2A)') 'INITENVIHOP initEnv: ', & 
                                      'Unknown curvature condition'
                 CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-                STOP 'ABNORMAL END: S/R ReadEnvironment'
+                STOP 'ABNORMAL END: S/R initEnv'
           END SELECT
 
 #ifdef IHOP_WRITE_OUT
@@ -403,11 +403,11 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
         CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+            WRITE(msgBuf,'(2A)') 'INITENVIHOP initEnv: ', & 
                                 'Unknown beam type (second letter of run type)'
             CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-            STOP 'ABNORMAL END: S/R ReadEnvironment'
+            STOP 'ABNORMAL END: S/R initEnv'
         END SELECT
 
        ENDIF ! No output in adjoint mode
@@ -428,7 +428,7 @@ CONTAINS
     _END_MASTER(myThid)
 #endif /* IHOP_WRITE_OUT */
   RETURN
-  END !SUBROUTINE ReadEnvironment
+  END !SUBROUTINE initEnv
 
   !**********************************************************************!
 
@@ -494,7 +494,7 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadTopOpt: ', & 
                              'Unknown option for SSP approximation'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -536,7 +536,7 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadTopOpt: ', & 
                              'Unknown attenuation units'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -585,7 +585,7 @@ CONTAINS
     CASE ( ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in fourth position'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -601,7 +601,7 @@ CONTAINS
     CASE ( '-', '_', ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in fifth position'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -617,7 +617,7 @@ CONTAINS
     CASE ( ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in sixth position'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -696,7 +696,7 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadRunType: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadRunType: ', & 
             'Unknown RunType selected'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -776,7 +776,7 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        IF ( Pos%NRz /= Pos%NRr ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(2A)') 'READENVIHOP ReadRunType: ', & 
+            WRITE(msgBuf,'(2A)') 'INITENVIHOP ReadRunType: ', & 
                     'Irregular grid option selected with NRz not equal to Nr'
             CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -870,7 +870,7 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(2A)') 'READENVIHOP TopBot: ', & 
+        WRITE(msgBuf,'(2A)') 'INITENVIHOP TopBot: ', & 
                              'Unknown boundary condition type'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
@@ -1335,10 +1335,10 @@ CONTAINS
 
     ! *** TITLE ***
 #ifdef IHOP_THREED
-    WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+    WRITE(msgBuf,'(2A)') 'INITENVIHOP openPRTFile: ', & 
                          '3D not supported in ihop'
     CALL PRINT_ERROR( msgBuf,myThid )
-    STOP 'ABNORMAL END: S/R ReadEnvironment'
+    STOP 'ABNORMAL END: S/R initEnv'
     Title( 1 :11 ) = 'iHOP3D - '
     Title( 12:80 ) = IHOP_title
 #else /* not IHOP_THREED */
@@ -1399,7 +1399,7 @@ CONTAINS
     IF (ALLOCATED(Pos%theta))   DEALLOCATE(Pos%theta)
     IF (ALLOCATED(Arr))         DEALLOCATE(Arr)
     IF (ALLOCATED(NArr))        DEALLOCATE(NArr)
-    ! from readenvihop
+    ! from initenvihop
     IF (ALLOCATED(Pos%Sx))      DEALLOCATE(Pos%Sx)
     IF (ALLOCATED(Pos%Sy))      DEALLOCATE(Pos%Sy)
     IF (ALLOCATED(Pos%Sz))      DEALLOCATE(Pos%Sz)
@@ -1432,4 +1432,4 @@ CONTAINS
 
   END ! SUBROUTINE resetMemory
 
-END MODULE readEnviHop
+END MODULE initenvihop

--- a/src/ssp_mod.F90
+++ b/src/ssp_mod.F90
@@ -871,10 +871,15 @@ SUBROUTINE ExtractSSP( Depth, myThid )
   REAL (KIND=_RL90)             :: sumweights(IHOP_NPTS_RANGE, Nr), &
                                    dcdz, tolerance
   REAL (KIND=_RL90), ALLOCATABLE:: tmpSSP(:,:,:,:)
+  REAL (KIND=_RL90), ALLOCATABLE:: sspcmat(:)
   LOGICAL :: found_interpolation, skip_range
 
   SSP%Nz = Nr+2 ! add z=0 z=Depth layers 
   SSP%Nr = IHOP_NPTS_RANGE
+
+  ! Local allocation
+  IF ( ALLOCATED(sspcmat) ) DEALLOCATE(sspcmat)
+  ALLOCATE( sspcmat(SSP%Nr) )
 
   ALLOCATE( SSP%cMat( SSP%Nz, SSP%Nr ), &
             SSP%czMat( SSP%Nz-1, SSP%Nr ), &
@@ -1101,7 +1106,8 @@ SUBROUTINE ExtractSSP( Depth, myThid )
     WRITE(msgBuf,'(A)') ' Depth (m)     Soundspeed (m/s)'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     DO iz = 1, SSP%Nz
-      WRITE(msgBuf,'(12F10.2)'  ) SSP%z( iz ), SSP%cMat( iz, : )
+      sspcmat = ssp%cMat( iz,: )
+      WRITE(msgBuf,'(12F10.2)') SSP%z( iz ), SSPcMat
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END DO
   ENDIF


### PR DESCRIPTION
Cost function is now usable and correct for MPI parallelized MITgcm models. Had to rearrange memory allocation to a subroutine seen by all processes, `ihop_init` in `bellhop` module. 