### PR TITLE
TAF warning reduction

### DIFF
--- a/src/atten_mod.F90
+++ b/src/atten_mod.F90
@@ -77,8 +77,6 @@ CONTAINS
     REAL    (KIND=_RL90)            :: f2, afreq, alphaT, Thorp, a, FG
     COMPLEX (KIND=_RL90)            :: CRCI
 
-!ADJ PASSIVE beta, fT
-
     afreq = 2.0 * PI * IHOP_freq
 
     !  Convert to Nepers/m 

--- a/src/bdry_mod.F90
+++ b/src/bdry_mod.F90
@@ -141,40 +141,42 @@ CONTAINS
 
        ! In adjoint mode we do not write output besides on the first run
        IF (IHOP_dumpfreq.GE.0) THEN
-       AltiType: SELECT CASE ( atiType( 1 : 1 ) )
+       SELECT CASE ( atiType( 1:1 ) )
 
-       CASE ( 'C' )
+        CASE ( 'C' )
 #ifdef IHOP_WRITE_OUT
           WRITE(msgBuf,'(A)') 'Curvilinear Interpolation'
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
-       CASE ( 'L' )
+        CASE ( 'L' )
 #ifdef IHOP_WRITE_OUT
           WRITE(msgBuf,'(A)') 'Piecewise linear interpolation'
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
-       CASE DEFAULT
+        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
             WRITE(msgBuf,'(2A)') 'BDRYMOD initATI', &
                        'Unknown option for selecting altimetry interpolation'
             CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R initATI'
-       END SELECT AltiType
+       END SELECT
        ENDIF
 
 
        READ(  ATIFile, * ) NAtiPts
 #ifdef IHOP_WRITE_OUT
        WRITE(msgBuf,'(A,I10)') 'Number of altimetry points = ', NAtiPts
-       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       ! In adjoint mode we do not write output besides on the first run
+       IF (IHOP_dumpfreq.GE.0) &
+         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
        ! we'll be extending the altimetry to infinity to the left and right
        NAtiPts = NAtiPts + 2  
 
-       IF (ALLOCATED(phi)) DEALLOCATE(phi)
-       ALLOCATE( Top(  NAtiPts ), phi( NAtiPts ), Stat = IAllocStat )
+       IF (ALLOCATED(Top)) DEALLOCATE(Top)
+       ALLOCATE( Top( NAtiPts ), Stat = IAllocStat )
        IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
             WRITE(msgBuf,'(2A)') 'BDRYMOD initATI', &
@@ -197,7 +199,7 @@ CONTAINS
        ! Read in the altimetry
        atiPt: DO ii = 2, NAtiPts - 1
 
-          SELECT CASE ( atiType( 2 : 2 ) )
+          SELECT CASE ( atiType( 2:2 ) )
           CASE ( 'S', '' )
             READ( ATIFile, * ) Top( ii )%x
 #ifdef IHOP_WRITE_OUT
@@ -359,26 +361,26 @@ CONTAINS
  
          ! In adjoint mode we do not write output besides on the first run
          IF (IHOP_dumpfreq.GE.0) THEN
-         BathyType: SELECT CASE ( btyType( 1 : 1 ) )
+         SELECT CASE ( btyType( 1:1 ) )
 
-        CASE ( 'C' )
+            CASE ( 'C' )
 # ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(A)') 'Curvilinear Interpolation'
-            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+              WRITE(msgBuf,'(A)') 'Curvilinear Interpolation'
+              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 # endif /* IHOP_WRITE_OUT */
-        CASE ( 'L' )
+            CASE ( 'L' )
 # ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(A)') 'Piecewise linear interpolation'
-            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+              WRITE(msgBuf,'(A)') 'Piecewise linear interpolation'
+              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 # endif /* IHOP_WRITE_OUT */
-        CASE DEFAULT
+            CASE DEFAULT
 # ifdef IHOP_WRITE_OUT
-            WRITE(msgBuf,'(2A)') 'BDRYMOD initBTY: ', &
-               'Unknown option for selecting bathymetry interpolation'
-            CALL PRINT_ERROR( msgBuf,myThid )
+              WRITE(msgBuf,'(2A)') 'BDRYMOD initBTY: ', &
+                 'Unknown option for selecting bathymetry interpolation'
+              CALL PRINT_ERROR( msgBuf,myThid )
 # endif /* IHOP_WRITE_OUT */
-            STOP 'ABNORMAL END: S/R initBTY'
-        END SELECT BathyType
+              STOP 'ABNORMAL END: S/R initBTY'
+        END SELECT
         ENDIF
 
 
@@ -410,15 +412,15 @@ CONTAINS
       WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
-      BathyTypeB: SELECT CASE ( btyType( 2:2 ) )
-      CASE ( 'S', '' )
+      SELECT CASE ( btyType( 2:2 ) )
+        CASE ( 'S', '' )
 # ifdef IHOP_WRITE_OUT
          WRITE(msgBuf,'(A)') 'Short format (bathymetry only)'
          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
          WRITE(msgBuf,'(A)') ' Range (km)  Depth (m)'
          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 # endif /* IHOP_WRITE_OUT */
-       CASE ( 'L' )
+        CASE ( 'L' )
 # ifdef IHOP_WRITE_OUT
          WRITE(msgBuf,'(A)') 'Long format (bathymetry and geoacoustics)'
          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -428,14 +430,14 @@ CONTAINS
          WRITE(msgBuf,'(A)') 
          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 # endif /* IHOP_WRITE_OUT */
-      CASE DEFAULT
+        CASE DEFAULT
 # ifdef IHOP_WRITE_OUT
          WRITE(msgBuf,'(2A)') 'BDRYMOD initBTY: ', &
             'Unknown option for selecting bathymetry interpolation'
          CALL PRINT_ERROR( msgBuf,myThid )
 # endif /* IHOP_WRITE_OUT */
          STOP 'ABNORMAL END: S/R initBTY'
-      END SELECT BathyTypeB
+      END SELECT
     ENDIF
 
       ! R_low check of gcm depths, change to positive values
@@ -512,7 +514,6 @@ CONTAINS
 # endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R initBTY'
          END IF
- 
       END DO btyPt
 
       CLOSE( BTYFile )
@@ -554,16 +555,23 @@ CONTAINS
    END IF 
 
 
+    ! Initiate Bot
+    DO ii = 1, NBtyPts
+       ! compressional wave speed
+       Bot( ii )%HS%cP = -999.
+       ! shear wave speed
+       Bot( ii )%HS%cS = -999.
+    END DO
    ! convert range-dependent geoacoustic parameters from user to program units
    ! W is dB/wavelength
    IF ( btyType( 2:2 ) == 'L' ) THEN
       DO ii = 1, NBtyPts
          ! compressional wave speed
-         Bot( ii )%HS%cp = CRCI( 1D20, Bot( ii )%HS%alphaR, &
+         Bot( ii )%HS%cP = CRCI( 1D20, Bot( ii )%HS%alphaR, &
                                    Bot( ii )%HS%alphaI, 'W ', bPower, fT, &
                                    myThid )
          ! shear wave speed
-         Bot( ii )%HS%cs = CRCI( 1D20, Bot( ii )%HS%betaR,  &
+         Bot( ii )%HS%cS = CRCI( 1D20, Bot( ii )%HS%betaR,  &
                                    Bot( ii )%HS%betaI, 'W ', bPower, fT, &
                                    myThid )
       END DO

--- a/src/bdry_mod.F90
+++ b/src/bdry_mod.F90
@@ -37,6 +37,7 @@ MODULE bdry_mod
 
    INTEGER, PARAMETER :: Number_to_Echo = 21
    INTEGER            :: IsegTop, IsegBot ! indices point to current active segment
+   INTEGER, PROTECTED :: NBtyPts = 2, NAtiPts = 2
    INTEGER            :: IOStat, IAllocStat
 
    ! range intervals defining the current active segment
@@ -64,7 +65,7 @@ MODULE bdry_mod
                            Noden( 2 )    ! normal at the node 
       REAL (KIND=_RL90) :: Dx, Dxx, &    ! 1st, 2nd derivatives wrt depth
                            Dss           ! derivative along tangent
-      TYPE( HSInfo )   :: HS
+      TYPE( HSInfo )    :: HS
    END TYPE
 
    TYPE(BdryPt), ALLOCATABLE :: Top( : ), Bot( : )
@@ -96,7 +97,6 @@ CONTAINS
   !     == Local Variables ==
     CHARACTER (LEN= 1), INTENT( IN ) :: TopATI
     INTEGER :: ii
-    INTEGER :: NAtiPts = 2
     REAL (KIND=_RL90),  INTENT( IN ) :: DepthT
     REAL (KIND=_RL90),  ALLOCATABLE  :: phi(:)
     REAL (KIND=_RL90),  ALLOCATABLE  :: x(:) 
@@ -315,16 +315,15 @@ CONTAINS
    !     == Local Variables ==
       CHARACTER (LEN= 1), INTENT( IN ) :: BotBTY
       INTEGER :: i,j,bi,bj,ii
-      INTEGER :: NBtyPts = 2
       REAL (KIND=_RL90),  INTENT( IN ) :: DepthB
       REAL (KIND=_RL90) :: gcmbathy(sNx,sNy), gcmmin, gcmmax
       REAL (KIND=_RL90), ALLOCATABLE :: x(:) 
       LOGICAL :: firstnonzero
       REAL (KIND=_RL90)   :: bPower, fT
 
-  ! IESCO24 fT init
-  bPower = 1.0
-  fT     = 1000.0
+      ! IESCO24 fT init
+      bPower = 1.0
+      fT     = 1000.0
 
       SELECT CASE ( BotBTY )
       CASE ( '~', '*' )
@@ -592,6 +591,7 @@ CONTAINS
     TYPE(BdryPt)                     :: Bdry( : )
     CHARACTER (LEN=3),  INTENT( IN ) :: BotTop ! Flag indicating bottom or top reflection
     CHARACTER (LEN=2)                :: CurvilinearFlag = '-'
+    INTEGER :: ii
 
     SELECT CASE ( BotTop )
     CASE ( 'Bot' )

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -25,8 +25,8 @@ MODULE BELLHOP
   ! Systems Center
 
   
-  USE ihop_mod,     only:   rad2deg, i, Beam, ray2D, NRz_per_range, afreq, &
-                            SrcDeclAngle, iSmallStepCtr, &
+  USE ihop_mod,     only:   rad2deg, i, Beam, ray2D, NRz_per_range, afreq,     &
+                            SrcDeclAngle, iSmallStepCtr,                       &
                             PRTFile, SHDFile, ARRFile, RAYFile, DELFile   
   USE initenvihop,  only:   initEnv, openOutputFiles, resetMemory
   USE angle_mod,    only:   Angles, ialpha

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -26,7 +26,7 @@ MODULE BELLHOP
 
   
   USE ihop_mod,     only:   rad2deg, i, MaxN, Title, Beam, ray2D, istep,       &
-                            NRz_per_range, afreq, SrcDeclAngle,                &
+                            NRz_per_range, afreq, SrcDeclAngle, iSmallStepCtr, &
                             PRTFile, SHDFile, ARRFile, RAYFile, DELFile   
   USE initenvihop,  only:   initEnv, openOutputFiles, resetMemory
   USE angle_mod,    only:   Angles, ialpha
@@ -34,12 +34,12 @@ MODULE BELLHOP
   USE ssp_mod,      only:   evalSSP, SSP
   !HSInfo, Bdry, 
   USE bdry_mod,     only:   initATI, initBTY, GetTopSeg, GetBotSeg, Bot, Top,  &
-                            atiType, btyType, NatiPts, NbtyPts, iSmallStepCtr, &
-                            IsegTop, IsegBot, rTopSeg, rBotSeg, Bdry
+                            atiType, btyType, IsegTop, IsegBot,                &
+                            rTopSeg, rBotSeg, Bdry
   USE refCoef,      only:   readReflectionCoefficient,                         &
                             InterpolateReflectionCoefficient, ReflectionCoef,  &
                             RTop, RBot, NBotPts, NTopPts
-  USE influence,    only:   InfluenceGeoHatRayCen,&! InfluenceSGB,             &
+  USE influence,    only:   InfluenceGeoHatRayCen,                             &
                             InfluenceGeoGaussianCart, InfluenceGeoHatCart,     &
                             ScalePressure
   USE beamPattern 

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -397,7 +397,7 @@ CONTAINS
        DeclinationAngle: DO ialpha = 1, Angles%Nalpha
 
 !$TAF store arr,narr,u = BellhopCore2
-!$TAF store beam%nsteps,beam%runtype = BellhopCore2
+!!$TAF store beam%nsteps,beam%runtype = BellhopCore2
 
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components
@@ -406,7 +406,7 @@ CONTAINS
 
 ! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
 ! Scalar components
-!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
+!!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
 ! Fixed arrays
 ! Allocatable arrays
 !$TAF store ssp%cmat,ssp%czmat = BellhopCore2
@@ -435,7 +435,7 @@ CONTAINS
 !$TAF store amp0,beam%runtype,beam%nsteps = BellhopCore2
 ! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
 ! Scalar components
-!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
+!!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
 !$TAF store bdry%top%hs%cp,bdry%top%hs%cs,bdry%top%hs%rho = BellhopCore2
 ! Fixed arrays
 ! Allocatable arrays
@@ -539,7 +539,6 @@ CONTAINS
 !$TAF init TraceRay2D = static, MaxN-1 
 !$TAF init TraceRay2D1 = 'bellhop_traceray2d'
 
-!$TAF store beam%runtype = TraceRay2D1
 ! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
 ! Scalar components
 !$TAF store ssp = TraceRay2D1
@@ -678,6 +677,8 @@ CONTAINS
   
          ! IESCO22: Did new ray point cross top boundary? Then reflect
          IF ( DistBegTop > 0.0d0 .AND. DistEndTop <= 0.0d0 ) THEN 
+
+!$TAF store isegtop = TraceRay2D
   
             IF ( atiType == 'C' ) THEN ! curvilinear interpolation
                ! proportional distance along segment
@@ -692,6 +693,8 @@ CONTAINS
                ToptInt = Top( IsegTop )%t
             END IF
   
+!$TAF store is,isegtop = TraceRay2D
+  
             CALL Reflect2D( is, Bdry%Top%HS,    'TOP',  ToptInt,    TopnInt, &
                                 Top( IsegTop )%kappa,   RTop,       NTopPTS, &
                                 myThid ) 
@@ -702,6 +705,8 @@ CONTAINS
   
          ! IESCO22: Did ray cross bottom boundary? Then reflect
          ELSE IF ( DistBegBot > 0.0d0 .AND. DistEndBot <= 0.0d0 ) THEN
+  
+!$TAF store isegbot = TraceRay2D
   
             IF ( btyType == 'C' ) THEN ! curvilinear interpolation
                ! proportional distance along segment
@@ -716,6 +721,8 @@ CONTAINS
                BottInt = Bot( IsegBot )%t
             END IF
   
+!$TAF store is,isegbot = TraceRay2D
+
             CALL Reflect2D( is, Bdry%Bot%HS,    'BOT',  BottInt,    BotnInt, &
                                 Bot( IsegBot )%kappa,   RBot,       NBotPTS, &
                                 myThid ) 

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -25,8 +25,8 @@ MODULE BELLHOP
   ! Systems Center
 
   
-  USE ihop_mod,     only:   rad2deg, i, MaxN, Title, Beam, ray2D, istep,       &
-                            NRz_per_range, afreq, SrcDeclAngle, iSmallStepCtr, &
+  USE ihop_mod,     only:   rad2deg, i, Beam, ray2D, NRz_per_range, afreq, &
+                            SrcDeclAngle, iSmallStepCtr, &
                             PRTFile, SHDFile, ARRFile, RAYFile, DELFile   
   USE initenvihop,  only:   initEnv, openOutputFiles, resetMemory
   USE angle_mod,    only:   Angles, ialpha
@@ -482,6 +482,7 @@ CONTAINS
   
   ! Traces the beam corresponding to a particular take-off angle, alpha [rad]
   
+    USE ihop_mod, only: MaxN, istep
     USE step,     only: Step2D
     USE ssp_mod,  only: iSegr           !RG
   !     == Routine Arguments ==

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -357,7 +357,6 @@ CONTAINS
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     SourceDepth: DO is = 1, Pos%NSz
 
-!$TAF store beam = BellhopCore1
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components
 ! Fixed arrays
@@ -396,13 +395,23 @@ CONTAINS
   
        ! Trace successive beams
        DeclinationAngle: DO ialpha = 1, Angles%Nalpha
-!$TAF store arr,bdry,narr,u = BellhopCore2
-!!$TAF store ratio1,rb = BellhopCore2
+
+!$TAF store arr,narr,u = BellhopCore2
+!$TAF store beam%nsteps,beam%runtype = BellhopCore2
+
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components
 ! Fixed arrays
 ! Allocatable arrays
+
+! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
+! Scalar components
+!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
+! Fixed arrays
+! Allocatable arrays
 !$TAF store ssp%cmat,ssp%czmat = BellhopCore2
+
+
           ! take-off declination angle in degrees
           SrcDeclAngle = rad2deg * Angles%alpha( ialpha )
   
@@ -423,6 +432,14 @@ CONTAINS
              Amp0 = ( 1 - s ) * SrcBmPat( IBP, 2 ) + s * SrcBmPat( IBP + 1, 2 )
              ! IEsco22: When a beam pattern isn't specified, Amp0 = 0
   
+!$TAF store amp0,beam%runtype,beam%nsteps = BellhopCore2
+! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
+! Scalar components
+!$TAF store bdry%bot%hs%cp,bdry%bot%hs%cs,bdry%bot%hs%rho = BellhopCore2
+!$TAF store bdry%top%hs%cp,bdry%top%hs%cs,bdry%top%hs%rho = BellhopCore2
+! Fixed arrays
+! Allocatable arrays
+
              ! Lloyd mirror pattern for semi-coherent option
              IF ( Beam%RunType( 1:1 ) == 'S' ) &
                 Amp0 = Amp0 * SQRT( 2.0 ) * ABS( SIN( afreq / c * xs( 2 ) &
@@ -520,6 +537,13 @@ CONTAINS
     LOGICAL           :: RayTurn = .FALSE., continue_steps
   
 !$TAF init TraceRay2D = static, MaxN-1 
+!$TAF init TraceRay2D1 = 'bellhop_traceray2d'
+
+!$TAF store beam%runtype = TraceRay2D1
+! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
+! Scalar components
+!$TAF store ssp = TraceRay2D1
+!$TAF store beam = TraceRay2D1
 
     ! Initial conditions (IC)
     iSmallStepCtr = 0
@@ -582,18 +606,26 @@ CONTAINS
     is = 0
     continue_steps = .true.
     Stepping: DO istep = 1, MaxN - 1
-!$TAF store bdry,beam,continue_steps,distbegbot,distbegtop = TraceRay2D
-!$TAF store isegbot,isegtop,ray2d,rbotseg,rtopseg = TraceRay2D
+
+!$TAF store is,beam,continue_steps,distbegbot,distbegtop = TraceRay2D
+
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components
 ! Fixed arrays
 ! Allocatable arrays
 !$TAF store ssp%cmat,ssp%czmat = TraceRay2D
+
+! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
+! Scalar components
+!$TAF store bdry%top%hs%cp,bdry%top%hs%cs,bdry%top%hs%rho = TraceRay2D
+
        IF ( continue_steps ) THEN
-!$TAF store is = TraceRay2D
          is  = is + 1 ! old step
          is1 = is + 1 ! new step forward
   
+!$TAF store is,isegbot,isegtop,rbotseg,rtopseg = TraceRay2D
+!$TAF store ray2d = TraceRay2D
+
          CALL Step2D( ray2D( is ), ray2D( is1 ),  &
               Top( IsegTop )%x, Top( IsegTop )%n, &
               Bot( IsegBot )%x, Bot( IsegBot )%n, myThid )

--- a/src/bellhop.F90
+++ b/src/bellhop.F90
@@ -91,6 +91,8 @@ CONTAINS
     INTEGER, PARAMETER   :: ArrivalsStorage = 2000, MinNArr = 10
   ! ===========================================================================
  
+!$TAF init ihop_init1 = 'BellhopIhop_init'
+
     ! Open the print file: template from eeboot_minimal.F
 #ifdef IHOP_WRITE_OUT
     IF ( .NOT.usingMPI ) THEN
@@ -138,6 +140,18 @@ CONTAINS
 # endif /* ALLOW_USE_MPI */
     END IF
 #endif /* IHOP_WRITE_OUT */
+
+! IESCO24: Write derived type with allocatable memory by type: Pos from srpos_mod
+! Scalar components
+! Allocatable arrays
+!$TAF store pos%wr,pos%ws = ihop_init1
+
+! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
+! Scalar components
+! Fixed arrays
+!$TAF store ssp%z = ihop_init1
+! Allocatable arrays
+!$TAF store ssp%czmat,ssp%seg%r,ssp%seg%x,ssp%seg%y,ssp%seg%z = ihop_init1
 
     ! Reset memory
     CALL resetMemory() 
@@ -347,7 +361,6 @@ CONTAINS
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components
 ! Fixed arrays
-!$TAF store ssp%z = BellhopCore1
 ! Allocatable arrays
 !$TAF store ssp%cmat,ssp%czmat = BellhopCore1
 
@@ -383,7 +396,7 @@ CONTAINS
   
        ! Trace successive beams
        DeclinationAngle: DO ialpha = 1, Angles%Nalpha
-!$TAF store arr,bdry,isegr,narr,u = BellhopCore2
+!$TAF store arr,bdry,narr,u = BellhopCore2
 !!$TAF store ratio1,rb = BellhopCore2
 ! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
 ! Scalar components

--- a/src/cost_ihop.F
+++ b/src/cost_ihop.F
@@ -167,7 +167,7 @@ C Combine all threads here
 C Combine MPI processes
        DO ii=1,NOBSMAX_IHOP
         tmpgs = ihopObs_buff(ii)
-        _GLOBAL_SUM_RL (tmpgs, myThid) 
+        _GLOBAL_SUM_RL(tmpgs, myThid) 
         ihopObs_modval_glob(ii) = tmpgs
        ENDDO     
 

--- a/src/ihop_ad.flow
+++ b/src/ihop_ad.flow
@@ -67,7 +67,7 @@
 !$TAF SUBROUTINE bdry_mod::initbty OUTPUT  =
 !$TAF SUBROUTINE bdry_mod::initati MODULE bdry_mod OUTPUT  = bot
 
-!$TAF SUBROUTINE bdry_mod::computebdrytangentnormal INPUT   = 1, 2
+!$TAF SUBROUTINE bdry_mod::computebdrytangentnormal INPUT   = 1, 2, 3
 !$TAF SUBROUTINE bdry_mod::computebdrytangentnormal OUTPUT  =
 
 !     *==========================================================*

--- a/src/ihop_mod.F90
+++ b/src/ihop_mod.F90
@@ -28,7 +28,7 @@ MODULE ihop_mod
             PRTFile, RAYFile, DELFile, SHDFile, ARRFile, SSPFile,&
             ATIFile, BTYFile, BRCFile, TRCFile, IRCFile, SBPFile,& 
             MaxN, Nrz_per_range, iStep, afreq, SrcDeclAngle,     &
-            Title, Beam, ray2D, ray2DPt
+            Title, Beam, ray2D, ray2DPt, iSmallStepCtr
 
 !=======================================================================
 
@@ -50,6 +50,7 @@ MODULE ihop_mod
                         MaxN = 100000
 
   ! *** varying parameters for ihop ***
+  INTEGER            :: iSmallStepCtr = 0
   INTEGER            :: Nrz_per_range, iStep
   REAL (KIND=_RL90)  :: afreq, SrcDeclAngle, SrcAzimAngle
   CHARACTER (LEN=80) :: Title

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -164,13 +164,14 @@ CONTAINS
        
            ! Compute influence for each receiver
            DO ir = irA + 1 - II, irB + II, SIGN(1, irB - irA)
-!$TAF store Arr(:,ir,iz),NArr(ir,iz),w = iRayCen2
+!$TAF store Arr(:,ir,iz),NArr(ir,iz) = iRayCen2
              W = (Pos%Rr(ir) - rA) / (rB - rA)  ! relative range between rR
              n = ABS(nA + W * (nB - nA))
              q = ray2D(iS - 1)%q(1) + W * dq(iS - 1)  ! interpolated amplitude
              L = ABS(q) / q0   ! beam radius
        
              IF (n < L) THEN  ! in beam window: update delay, Amp, phase
+!$TAF store w = iRayCen2
                delay = ray2D(iS - 1)%tau + W * dtau(iS - 1)
                Amp = ray2D(iS)%Amp / SQRT(ABS(q))
                W = (L - n) / L  ! hat function: 1 on center, 0 on edge
@@ -249,10 +250,10 @@ CONTAINS
        rayt = ray2D( iS )%x - x_ray 
        rlen = NORM2( rayt )
        ! if duplicate point in ray, skip to next step along the ray
+       IF ( rlen .GE. 1.0D3 * SPACING( ray2D( iS )%x( 1 ) ) ) THEN 
 
 !$TAF store rlen,rayt= iiitape1
 
-       IF ( rlen .GE. 1.0D3 * SPACING( ray2D( iS )%x( 1 ) ) ) THEN 
         rayt = rayt / rlen                    ! unit tangent of ray @ A
         rayn = [ -rayt( 2 ), rayt( 1 ) ]      ! unit normal  of ray @ A
         RcvrDeclAngle = rad2deg * ATAN2( rayt( 2 ), rayt( 1 ) )
@@ -420,6 +421,9 @@ CONTAINS
        rlen = NORM2( rayt )
        ! if duplicate point in ray, skip to next step along the ray
        IF ( rlen .GE. 1.0D3 * SPACING( ray2D( iS )%x( 1 ) ) ) THEN
+
+!$TAF store rlen,rayt = iGauCart1
+
         rayt = rayt / rlen
         rayn = [ -rayt( 2 ), rayt( 1 ) ]      ! unit normal to ray
         RcvrDeclAngle = rad2deg * ATAN2( rayt( 2 ), rayt( 1 ) )

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -166,7 +166,7 @@ CONTAINS
        
            ! Compute influence for each receiver
            DO ir = irA + 1 - II, irB + II, SIGN(1, irB - irA)
-!$TAF store Arr(:,ir,iz),NArr(ir,iz),W = iRayCen2
+!$TAF store Arr(:,ir,iz),NArr(ir,iz) = iRayCen2
              W = (Pos%Rr(ir) - rA) / (rB - rA)  ! relative range between rR
              n = ABS(nA + W * (nB - nA))
              q = ray2D(iS - 1)%q(1) + W * dq(iS - 1)  ! interpolated amplitude
@@ -241,7 +241,7 @@ CONTAINS
     IF ( Beam%RunType( 4 : 4 ) == 'R' ) Ratio1 = SQRT( ABS( COS( alpha ) ) )  
 
     Stepping: DO iS = 2, Beam%Nsteps
-!$TAF store phase,qold,ra,rayt,rlen = iiitape1
+!$TAF store phase,qold,ra = iiitape1
        rB     = ray2D( iS   )%x( 1 )
        x_ray  = ray2D( iS-1 )%x
 
@@ -407,7 +407,7 @@ CONTAINS
     END IF
 
     Stepping: DO iS = 2, Beam%Nsteps
-!$TAF store phase,qold,ra,rayt = iGauCart1
+!$TAF store phase,qold,ra = iGauCart1
        rB    = ray2D( iS     )%x( 1 )
        x_ray = ray2D( iS - 1 )%x
 

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -11,7 +11,7 @@ MODULE influence
   ! mbp 12/2018, based on much older subroutines
 
   USE ihop_mod,     only: rad2deg, i, PRTFile, MaxN, Beam, ray2D, &
-                          SrcDeclAngle, NRz_per_range, afreq
+                          SrcDeclAngle, NRz_per_range
   USE srPos_mod,    only: Pos
 ! sspMod used to construct image beams in the Cerveny style beam routines
   USE arr_mod,      only: AddArr
@@ -529,6 +529,8 @@ CONTAINS
   ! **********************************************************************!
   
   SUBROUTINE ApplyContribution( U )
+    USE ihop_mod, only: afreq
+
     COMPLEX, INTENT( INOUT ) :: U
 
     SELECT CASE( Beam%RunType( 1:1 ) )
@@ -568,91 +570,7 @@ CONTAINS
   RETURN
   END !SUBROUTINE ApplyContribution
                  
-!  ! **********************************************************************!
-!
-!  SUBROUTINE InfluenceSGB( U, alpha, Dalpha )
-!
-!    ! Bucker's Simple Gaussian Beams in Cartesian coordinates
-!
-!    REAL (KIND=_RL90), INTENT( IN    ) :: alpha, dalpha ! take-off angle, angular spacing
-!    COMPLEX,           INTENT( INOUT ) :: U( NRz_per_range, Pos%NRr ) ! complex pressure field
-!    REAL (KIND=_RL90)     :: x( 2 ), rayt( 2 ), A, beta, cn, CPA, deltaz, DS, & 
-!                             sint, SX1, thet
-!    COMPLEX (KIND=_RL90)  :: contri, tau
-!
-!    Ratio1 = SQRT(  COS( alpha ) )
-!    phase  = 0
-!    qOld   = 1.0
-!    BETA   = 0.98  ! Beam Factor
-!    A      = -4.0 * LOG( BETA ) / Dalpha**2
-!    CN     = Dalpha * SQRT( A / PI )
-!    rA     = ray2D( 1 )%x( 1 )
-!    ir     = 1
-!
-!    Stepping: DO iS = 2, Beam%Nsteps
-!
-!       rB = ray2D( iS )%x( 1 )
-!
-!       ! phase shifts at caustics
-!       q  = ray2D( iS - 1 )%q( 1 )
-!       IF ( q < 0.0d0 .AND. qOld >= 0.0d0 &
-!            .OR. q > 0.0d0 .AND. qOld <= 0.0d0 ) &
-!        phase = phase + PI / 2.
-!       qold = q
-!
-!       RcvrRanges: DO WHILE ( ABS( rB - rA ) > 1.0D3 * SPACING( rA ) &
-!           .AND. rB > Pos%Rr( ir ) )   ! Loop over bracketted receiver ranges
-!
-!          W    = ( Pos%Rr( ir ) - rA ) / ( rB - rA )
-!          x    = ray2D( iS-1 )%x    + W * ( ray2D( iS )%x    - ray2D( iS-1 )%x )
-!          rayt = ray2D( iS-1 )%t    + W * ( ray2D( iS )%t    - ray2D( iS-1 )%t )
-!          q    = ray2D( iS-1 )%q(1) + W * ( ray2D( iS )%q(1) - ray2D( iS-1 )%q(1) )
-!          tau  = ray2D( iS-1 )%tau  + W * ( ray2D( iS )%tau  - ray2D( iS-1 )%tau )
-!
-!          ! following is incorrect because ray doesn't always use a step of deltas
-!          SINT = ( iS-1 ) * Beam%deltas + W * Beam%deltas
-!
-!          IF ( q < 0.0d0 .AND. qOld >= 0.0d0 &
-!               .OR. q > 0.0d0 .AND. qOld <= 0.0d0 ) &
-!            phase = phase + PI / 2. ! phase shifts at caustics
-!
-!          RcvrDepths: DO iz = 1, NRz_per_range
-!             deltaz =  Pos%Rz( iz ) - x( 2 )   ! ray to rcvr distance
-!             ! Adeltaz    = ABS( deltaz )
-!             ! IF ( Adeltaz < RadiusMax ) THEN
-!             SELECT CASE( Beam%RunType( 1:1 ) )
-!             CASE ( 'E', 'e' )         ! eigenrays
-!                SrcDeclAngle = rad2deg * alpha   ! take-off angle in degrees
-!                CALL WriteRay2D( SrcDeclAngle, iS )
-!                IF (writeDelay) CALL WriteDel2D( SrcDeclAngle, iS )
-!             CASE DEFAULT         ! coherent TL
-!                CPA    = ABS( deltaz * ( rB - rA ) ) / SQRT( ( rB - rA )**2 &
-!                         + ( ray2D( iS )%x( 2 ) - ray2D( iS-1 )%x( 2 ) )**2  )
-!                DS     = SQRT( deltaz **2 - CPA **2 )
-!                SX1    = SINT + DS
-!                thet   = ATAN( CPA / SX1 )
-!                delay  = tau + rayt( 2 ) * deltaz
-!                contri = Ratio1 * CN * ray2D( iS )%Amp &
-!                       * EXP( -A * thet**2 &
-!                              - i*( afreq*delay - ray2D( iS )%Phase - phase ) )&
-!                       / SQRT( SX1 )
-!                U( iz, ir ) = U( iz, ir ) + CMPLX( contri )
-!             END SELECT
-!             ! END IF
-!          END DO RcvrDepths
-!
-!          qOld = q
-!          ir   = ir + 1
-!          IF ( ir > Pos%NRr ) RETURN
-!       END DO RcvrRanges
-!
-!       rA = rB
-!    END DO Stepping
-!
-!  RETURN
-!  END !SUBROUTINE InfluenceSGB
-!
-  ! **********************************************************************!
+! **********************************************************************!
 
   SUBROUTINE ScalePressure( Dalpha, c, r, U, NRz, Nr, RunType, freq )
 

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -67,13 +67,11 @@ CONTAINS
 
     !!! need to add logic related to NRz_per_range
 
-!!$TAF init iRayCen0a = static, (Beam%Nsteps)
-!!$TAF init iRayCen0b = static, (Beam%Nsteps)*2 
+!$TAF init iRayCen0  = 'influence_iraycen'
 !$TAF init iRayCen1  = static, (Beam%Nsteps-1)*NRz_per_range
 !$TAF init iRayCen2  = static, (Beam%Nsteps-1)*ihop_nrr*NRz_per_range
 
-!!$TAF store ray2d(1:Beam%Nsteps)%amp,ray2d(1:Beam%Nsteps)%c = iRayCen0a
-!!$TAF store ray2d(1:Beam%Nsteps)%t(1:2) = iRayCen0b
+!$TAF store ray2d = iRayCen0
 
     q0           = ray2D( 1 )%c / Dalpha   ! Reference for J = q0 / q
     SrcDeclAngle = rad2deg * alpha          ! take-off angle in degrees
@@ -166,7 +164,7 @@ CONTAINS
        
            ! Compute influence for each receiver
            DO ir = irA + 1 - II, irB + II, SIGN(1, irB - irA)
-!$TAF store Arr(:,ir,iz),NArr(ir,iz) = iRayCen2
+!$TAF store Arr(:,ir,iz),NArr(ir,iz),w = iRayCen2
              W = (Pos%Rr(ir) - rA) / (rB - rA)  ! relative range between rR
              n = ABS(nA + W * (nB - nA))
              q = ray2D(iS - 1)%q(1) + W * dq(iS - 1)  ! interpolated amplitude
@@ -241,7 +239,9 @@ CONTAINS
     IF ( Beam%RunType( 4 : 4 ) == 'R' ) Ratio1 = SQRT( ABS( COS( alpha ) ) )  
 
     Stepping: DO iS = 2, Beam%Nsteps
+
 !$TAF store phase,qold,ra = iiitape1
+
        rB     = ray2D( iS   )%x( 1 )
        x_ray  = ray2D( iS-1 )%x
 
@@ -249,6 +249,9 @@ CONTAINS
        rayt = ray2D( iS )%x - x_ray 
        rlen = NORM2( rayt )
        ! if duplicate point in ray, skip to next step along the ray
+
+!$TAF store rlen,rayt= iiitape1
+
        IF ( rlen .GE. 1.0D3 * SPACING( ray2D( iS )%x( 1 ) ) ) THEN 
         rayt = rayt / rlen                    ! unit tangent of ray @ A
         rayn = [ -rayt( 2 ), rayt( 1 ) ]      ! unit normal  of ray @ A

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -67,8 +67,13 @@ CONTAINS
 
     !!! need to add logic related to NRz_per_range
 
-!$TAF init iRayCen1 = static, (Beam%Nsteps-1)*NRz_per_range
-!$TAF init iRayCen2 = static, (Beam%Nsteps-1)*ihop_nrr*NRz_per_range
+!!$TAF init iRayCen0a = static, (Beam%Nsteps)
+!!$TAF init iRayCen0b = static, (Beam%Nsteps)*2 
+!$TAF init iRayCen1  = static, (Beam%Nsteps-1)*NRz_per_range
+!$TAF init iRayCen2  = static, (Beam%Nsteps-1)*ihop_nrr*NRz_per_range
+
+!!$TAF store ray2d(1:Beam%Nsteps)%amp,ray2d(1:Beam%Nsteps)%c = iRayCen0a
+!!$TAF store ray2d(1:Beam%Nsteps)%t(1:2) = iRayCen0b
 
     q0           = ray2D( 1 )%c / Dalpha   ! Reference for J = q0 / q
     SrcDeclAngle = rad2deg * alpha          ! take-off angle in degrees
@@ -161,7 +166,7 @@ CONTAINS
        
            ! Compute influence for each receiver
            DO ir = irA + 1 - II, irB + II, SIGN(1, irB - irA)
-!$TAF store Arr(:,ir,iz),NArr(ir,iz) = iRayCen2
+!$TAF store Arr(:,ir,iz),NArr(ir,iz),W = iRayCen2
              W = (Pos%Rr(ir) - rA) / (rB - rA)  ! relative range between rR
              n = ABS(nA + W * (nB - nA))
              q = ray2D(iS - 1)%q(1) + W * dq(iS - 1)  ! interpolated amplitude
@@ -236,7 +241,7 @@ CONTAINS
     IF ( Beam%RunType( 4 : 4 ) == 'R' ) Ratio1 = SQRT( ABS( COS( alpha ) ) )  
 
     Stepping: DO iS = 2, Beam%Nsteps
-!$TAF store phase,qold,ra = iiitape1
+!$TAF store phase,qold,ra,rayt,rlen = iiitape1
        rB     = ray2D( iS   )%x( 1 )
        x_ray  = ray2D( iS-1 )%x
 
@@ -402,7 +407,7 @@ CONTAINS
     END IF
 
     Stepping: DO iS = 2, Beam%Nsteps
-!$TAF store phase,qold,ra = iGauCart1
+!$TAF store phase,qold,ra,rayt = iGauCart1
        rB    = ray2D( iS     )%x( 1 )
        x_ray = ray2D( iS - 1 )%x
 

--- a/src/initenvihop.F90
+++ b/src/initenvihop.F90
@@ -65,6 +65,8 @@ CONTAINS
     REAL (KIND=_RL90)  :: x(2), c, cimag, gradc(2), crz, czz, rho, Depth
     CHARACTER (LEN= 2) :: AttenUnit
     CHARACTER (LEN=10) :: PlotType
+    
+!$TAF init initEnv1 = 'initenvihop_initenv'
 
     ! init local variables
     AttenUnit = ''
@@ -133,6 +135,21 @@ CONTAINS
     Bdry%Bot%HS%BC = Bdry%Bot%HS%Opt( 1:1 )
     CALL TopBot( AttenUnit, Bdry%Bot%HS, myThid )
 
+! IESCO24: Write derived type with allocatable memory by type: Bdry from bdry_mod
+! Scalar components
+!$TAF store bdry%top%hs%depth,bdry%top%hs%bc = initEnv1
+
+! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
+! Scalar components
+! Fixed arrays
+! Allocatable arrays
+!$TAF store ssp%czmat,ssp%seg%r,ssp%seg%x,ssp%seg%y,ssp%seg%z = initEnv1
+
+! IESCO24: Write derived type with allocatable memory by type: Pos from srpos_mod
+! Scalar components
+! Allocatable arrays
+!$TAF store pos%rr = initEnv1
+!$TAF store pos%theta,pos%wr,pos%ws = initEnv1
 
     ! *** Ocean SSP ***
     x = [ 0.0 _d 0, Bdry%Bot%HS%Depth ]   ! tells SSP Depth to read to

--- a/src/srpos_mod.F90
+++ b/src/srpos_mod.F90
@@ -187,9 +187,11 @@ CONTAINS
   !     msgBuf :: Used to build messages for printing.
     INTEGER, INTENT( IN )   :: myThid
     CHARACTER*(MAX_LEN_MBUF):: msgBuf
-  
+
   !     == Local Variables ==
     REAL(KIND=_RL90),    INTENT( IN ) :: zMin, zMax
+
+!$TAF init readszrz1 = 'srpos_mod_readszrz'
 
     CALL ReadVector( Pos%NSz, Pos%Sz, 'Source   depths, Sz', 'm', &
                     myThid )
@@ -222,6 +224,8 @@ CONTAINS
     Pos%wr = 0
     Pos%irz = 0
 
+!$TAF store pos%nrz,pos%nsz,pos%rz,pos%sz = readszrz1
+  
     ! *** Check for Sz/Rz in water column ***
 #ifdef IHOP_WRITE_OUT
     ! In adjoint mode we do not write output besides on the first run

--- a/src/srpos_mod.F90
+++ b/src/srpos_mod.F90
@@ -224,12 +224,11 @@ CONTAINS
     Pos%wr = 0
     Pos%irz = 0
 
-!$TAF store pos%nrz,pos%nsz,pos%rz,pos%sz = readszrz1
-  
     ! *** Check for Sz/Rz in water column ***
 #ifdef IHOP_WRITE_OUT
     ! In adjoint mode we do not write output besides on the first run
     IF (IHOP_dumpfreq.GE.0) THEN
+!$TAF store pos%nrz,pos%nsz,pos%rz,pos%sz = readszrz1
         IF ( ANY( Pos%Sz( 1:Pos%NSz ) < zMin ) ) THEN
            WHERE ( Pos%Sz < zMin ) Pos%Sz = zMin
            WRITE(msgBuf,'(2A)') 'Warning in ReadSzRz : Source above or too ',&

--- a/src/ssp_mod.F90
+++ b/src/ssp_mod.F90
@@ -108,6 +108,14 @@ CONTAINS
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     INTEGER :: ir, iz
 
+!$TAF init initssp1 = 'ssp_mod_initssp'
+
+! IESCO24: Write derived type with allocatable memory by type: SSP from ssp_mod
+! Scalar components
+! Fixed arrays
+! Allocatable arrays
+!$TAF store ssp%cmat,ssp%czmat,ssp%seg%r,ssp%seg%x,ssp%seg%y,ssp%seg%z = initssp1
+
     ! All methods require Depth
     Depth = x( 2 )
     ! Check if SSPFile exists
@@ -923,6 +931,7 @@ SUBROUTINE ExtractSSP( Depth, myThid )
                   ELSE ! 2:(SSP%Nz-1)
                     ! Middle depth layers, only when not already underground
                     IF (sumweights(ii, iz - 1) .GT. 0.0) THEN
+!$TAF STORE njj(ii) = tape_ssp2                    !RG
                       ! Exactly on a cell center, ignore interpolation
                       IF (ihop_idw_weights(ii, jj) .EQ. 0.0) THEN
                         tmpSSP(iz, ii, bi, bj) = ihop_ssp(i, j, iz-1, bi, bj)

--- a/src/step.F90
+++ b/src/step.F90
@@ -173,6 +173,10 @@ CONTAINS
     ! and that multiple events can occur (crossing interface, top, and bottom 
     ! in a single step).
 
+!$TAF init reducestep2d = static, 100
+
+!$TAF store h = reducestep2d
+
     x = x0 + h * urayt ! take a trial Euler step
 
     ! interface crossing in depth

--- a/src/step.F90
+++ b/src/step.F90
@@ -153,8 +153,8 @@ CONTAINS
 
     ! calculate a reduced step size, h, that lands on any points where the 
     ! environment leaves water
-
-    USE bdry_mod, only: rTopSeg, rBotSeg, iSmallStepCtr
+    USE ihop_mod, only: iSmallStepCtr
+    USE bdry_mod, only: rTopSeg, rBotSeg
 
     INTEGER,           INTENT( IN    ) :: iSegz0, iSegr0  ! SSP layer ray is in
     ! ray coordinate and tangent

--- a/src/step.F90
+++ b/src/step.F90
@@ -173,7 +173,7 @@ CONTAINS
     ! and that multiple events can occur (crossing interface, top, and bottom 
     ! in a single step).
 
-!$TAF init reducestep2d = static, 100
+!$TAF init reducestep2d = static, 50 
 
 !$TAF store h = reducestep2d
 
@@ -209,7 +209,11 @@ CONTAINS
     rSeg( 1 ) = MAX( rTopSeg( 1 ), rBotSeg( 1 ) )
     rSeg( 2 ) = MIN( rTopSeg( 2 ), rBotSeg( 2 ) )
 
+!$TAF store rseg = reducestep2d
+
     IF ( SSP%Type == 'Q' ) THEN ! Quad: 2D range-dependent SSP
+!$TAF store rseg = reducestep2d
+
        rSeg( 1 ) = MAX( rSeg( 1 ), SSP%Seg%r( iSegr0     ) )
        rSeg( 2 ) = MIN( rSeg( 2 ), SSP%Seg%r( iSegr0 + 1 ) )
     END IF


### PR DESCRIPTION
Reduction of WARNING statements regarding the `ihop` package in `taf_ad.log`

Went from 356 to 174 WARNING messages.

Used TAF store directives to reduce warnings due to excessive recomputations. Also, rearranged scope of derived types to remove unecessary `use , only:` statements in `bdry_mod.F90`. 

To further reduce warnings, the package needs to completely remove fixed parameter initialization from the active subroutines. 