### PR TITLE
Angles%Dalpha patch

### DIFF
--- a/mitgcm_input/ad/data.grdchk
+++ b/mitgcm_input/ad/data.grdchk
@@ -2,7 +2,7 @@
 # ECCO gradient check
 # *******************
  &GRDCHK_NML
- grdchk_eps       = 1.d-2,
+ grdchk_eps       = 100.,
  iGloPos         = 12,
  jGloPos         = 38,
  kGloPos         = 2,

--- a/src/angle_mod.F90
+++ b/src/angle_mod.F90
@@ -146,6 +146,20 @@ CONTAINS
     ! store angles in radians
     Angles%arad = Angles%adeg * deg2rad
 
+    ! set uniform angle spacing
+    IF ( Angles%Nalpha > 1 ) THEN
+      Angles%Dalpha = ( Angles%arad( Angles%Nalpha ) - Angles%arad( 1 ) ) &
+                        / ( Angles%Nalpha - 1 )  ! angular spacing between beams
+    ELSE
+      Angles%Dalpha = 0.0
+#ifdef IHOP_WRITE_OUT
+      WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadRayElevationAngles: ', &
+                      'Required: Nalpha>1, else add iSingle_alpha'
+      CALL PRINT_ERROR( msgBuf,myThid )
+#endif /* IHOP_WRITE_OUT */
+      STOP 'ABNORMAL END: S/R ReadRayElevationAngles'
+    END IF
+
   RETURN
   END !SUBROUTINE ReadRayElevationAngles
 

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -205,21 +205,6 @@ CONTAINS
 
     afreq = 2.0 * PI * IHOP_freq
 
-    !Angles%alpha  = Angles%alpha * deg2rad  ! convert to radians
-    Angles%Dalpha = 0.0
-    IF ( Angles%Nalpha > 1 ) THEN
-      Angles%Dalpha = ( Angles%arad( Angles%Nalpha ) - Angles%arad( 1 ) ) &
-                        / ( Angles%Nalpha - 1 )  ! angular spacing between beams
-    ELSE
-      Angles%Dalpha = 0.0
-#ifdef IHOP_WRITE_OUT
-      WRITE(msgBuf,'(2A)') 'IHOP IHOPCore: ', &
-                      'Required: Nalpha>1, else add iSingle_alpha(see angleMod)'
-      CALL PRINT_ERROR( msgBuf,myThid )
-#endif /* IHOP_WRITE_OUT */
-      STOP 'ABNORMAL END: S/R IHOPCore'
-    END IF
-
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !         begin solve         !
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
`Angles%Dalpha` is now fully a passive component of the derived type `AnglesStructure` 

Before, we were experiencing issues with TAF identifying the component as an active variable. This was because there was a modification to `Angles%Dalpha` within the active subroutine `ihopcore`. 