### PR TITLE
ARRFile and RAYFile Formatting

### DIFF
--- a/mitgcm_input/data.ihop
+++ b/mitgcm_input/data.ihop
@@ -20,7 +20,7 @@
  IHOP_rr=2542.0,
 # e: eigenrays; G: Hat spreading
  IHOP_runopt='eG',
- IHOP_nalpha=4,
+ IHOP_nalpha=40,
  IHOP_alpha=-20.0, 20.0,
  &
 
@@ -32,6 +32,6 @@
  &
 
  &IHOP_COST_NML
- IHOPObs_Dir      = 'IHOP_obs/',
- IHOPObs_Files(1) = 'bcg_tau_obs_3',
+# IHOPObs_Dir      = 'IHOP_obs/',
+# IHOPObs_Files(1) = 'bcg_tau_obs_3',
  &

--- a/src/arr_mod.F90
+++ b/src/arr_mod.F90
@@ -168,23 +168,23 @@ CONTAINS
        IF ( Nt >= maxnArr ) THEN       ! space available to add an arrival?
           iArr = MINLOC( Arr( :, ir, iz )%A )   ! no: replace weakest arrival
           IF ( Amp > Arr( iArr(1), ir, iz )%A ) THEN
-             Arr( iArr(1), ir, iz )%A             = SNGL( Amp )       ! amplitude
-             Arr( iArr(1), ir, iz )%Phase         = SNGL( Phase )     ! phase
-             Arr( iArr(1), ir, iz )%delay         = CMPLX( delay )    ! delay time
-             Arr( iArr(1), ir, iz )%SrcDeclAngle  = SNGL( SrcDeclAngle )  ! angle
-             Arr( iArr(1), ir, iz )%RcvrDeclAngle = SNGL( RcvrDeclAngle ) ! angle
-             Arr( iArr(1), ir, iz )%NTopBnc       = NumTopBnc         ! # top bounces
-             Arr( iArr(1), ir, iz )%NBotBnc       = NumBotBnc         ! # bottom bounces
+             Arr( iArr(1), ir, iz)%A             = SNGL( Amp )       ! amplitude
+             Arr( iArr(1), ir, iz)%Phase         = SNGL( Phase )     ! phase
+             Arr( iArr(1), ir, iz)%delay         = CMPLX( delay )    ! delay time
+             Arr( iArr(1), ir, iz)%SrcDeclAngle  = SNGL( SrcDeclAngle)  ! angle
+             Arr( iArr(1), ir, iz)%RcvrDeclAngle = SNGL(RcvrDeclAngle) ! angle
+             Arr( iArr(1), ir, iz)%NTopBnc       = NumTopBnc         ! # top bounces
+             Arr( iArr(1), ir, iz)%NBotBnc       = NumBotBnc         ! # bottom bounces
           ENDIF
        ELSE
           nArr( ir, iz       )               = Nt + 1              ! # arrivals
-          Arr( Nt + 1, ir, iz)%A             = SNGL( Amp )         ! amplitude
-          Arr( Nt + 1, ir, iz)%Phase         = SNGL( Phase )       ! phase
-          Arr( Nt + 1, ir, iz)%delay         = CMPLX( delay )      ! delay time
-          Arr( Nt + 1, ir, iz)%SrcDeclAngle  = SNGL( SrcDeclAngle )    ! angle
-          Arr( Nt + 1, ir, iz)%RcvrDeclAngle = SNGL( RcvrDeclAngle )   ! angle
-          Arr( Nt + 1, ir, iz)%NTopBnc       = NumTopBnc           ! # top bounces
-          Arr( Nt + 1, ir, iz)%NBotBnc       = NumBotBnc           ! # bottom bounces
+          Arr( Nt+1, ir, iz)%A             = SNGL( Amp )         ! amplitude
+          Arr( Nt+1, ir, iz)%Phase         = SNGL( Phase )       ! phase
+          Arr( Nt+1, ir, iz)%delay         = CMPLX( delay )      ! delay time
+          Arr( Nt+1, ir, iz)%SrcDeclAngle  = SNGL( SrcDeclAngle )    ! angle
+          Arr( Nt+1, ir, iz)%RcvrDeclAngle = SNGL( RcvrDeclAngle )   ! angle
+          Arr( Nt+1, ir, iz)%NTopBnc       = NumTopBnc           ! # top bounces
+          Arr( Nt+1, ir, iz)%NBotBnc       = NumBotBnc           ! # bottom bounces
        ENDIF
     ELSE      ! not a new ray
        ! calculate weightings of old ray information vs. new, based on

--- a/src/arr_mod.F90
+++ b/src/arr_mod.F90
@@ -134,8 +134,9 @@ CONTAINS
   END !SUBROUTINE initArr( myThid )
 
 ! **************************************************************************** !
-  SUBROUTINE AddArr( afreq, iz, ir, Amp, Phase, delay, SrcDeclAngle, &
+  SUBROUTINE AddArr( afreq, iz, ir, Amp, Phase, delay, &
                      RcvrDeclAngle, NumTopBnc, NumBotBnc )
+    USE ihop_mod, only: SrcDeclAngle
 
     ! ADDs the amplitude and delay for an ARRival into a matrix of same.
     ! Extra logic included to keep only the strongest arrivals.
@@ -143,7 +144,7 @@ CONTAINS
     ! arrivals with essentially the same phase are grouped into one
     REAL,   PARAMETER                  :: PhaseTol = 0.05
     INTEGER,              INTENT( IN ) :: NumTopBnc, NumBotBnc, iz, ir
-    REAL    (KIND=_RL90), INTENT( IN ) :: afreq, Amp, Phase, SrcDeclAngle, &
+    REAL    (KIND=_RL90), INTENT( IN ) :: afreq, Amp, Phase, &
                                           RcvrDeclAngle
     COMPLEX (KIND=_RL90), INTENT( IN ) :: delay
     LOGICAL              :: NewRay

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -196,7 +196,7 @@ CONTAINS
 
   !     == Local Variables ==
     INTEGER           :: IBPvec(1), ibp, is, iBeamWindow2, Irz1, Irec, &
-                         nAlphaOpt
+                         nAlphaOpt, nSteps
     REAL(KIND=_RL90) :: Amp0, DalphaOpt, xs(2), RadMax, s, &
                          c, cimag, gradc(2), crr, crz, czz, rho
     REAL(KIND=_RL90) :: tmpDelay(maxN)
@@ -301,14 +301,15 @@ CONTAINS
 
              ! Write the ray trajectory to RAYFile
              IF ( Beam%RunType(1:1) == 'R') THEN
-                CALL WriteRayOutput( RAYFile, Beam%nSteps, &
-                    ray2D%x(1),ray2D%x(2), &
-                    ray2D(Beam%nSteps)%NumTopBnc,ray2D(Beam%nSteps)%NumBotBnc )
+                nSteps = Beam%nSteps
+                CALL WriteRayOutput( RAYFile, nSteps, &
+                    ray2D(1:nSteps)%x(1), ray2D(1:nSteps)%x(2), &
+                    ray2D(nSteps)%NumTopBnc,ray2D(nSteps)%NumBotBnc )
                 IF (writeDelay) THEN
-                  tmpDelay = REAL(ray2D%tau)
-                  CALL WriteRayOutput( DELFile, Beam%nSteps, &
-                    tmpDelay,ray2D%x(2), &
-                    ray2D(Beam%nSteps)%NumTopBnc,ray2D(Beam%nSteps)%NumBotBnc )
+                  tmpDelay = REAL(ray2D(1:nSteps)%tau)
+                  CALL WriteRayOutput( DELFile, nSteps, &
+                    tmpDelay, ray2D(1:nSteps)%x(2), &
+                    ray2D(nSteps)%NumTopBnc,ray2D(nSteps)%NumBotBnc )
                 ENDIF
 
              ELSE ! Compute the contribution to the field

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -526,6 +526,7 @@ CONTAINS
     INTEGER             :: IL
     REAL               :: atten
     CHARACTER (LEN=10) :: PlotType
+    CHARACTER (LEN=20) :: fmtstr
 
     ! add time step to filename
     IF (myIter.GE.0) THEN
@@ -592,18 +593,25 @@ CONTAINS
 
        ! write source locations
 # ifdef IHOP_THREED
-       WRITE( ARRFile, * ) Pos%nSX,    Pos%SX(    1 : Pos%nSX )
-       WRITE( ARRFile, * ) Pos%nSY,    Pos%SY(    1 : Pos%nSY )
-       WRITE( ARRFile, * ) Pos%nSZ,    Pos%SZ(    1 : Pos%nSZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # else /* IHOP_THREED */
-       WRITE( ARRFile, * ) Pos%nSZ,    Pos%SZ(    1 : Pos%nSZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
 
        ! write receiver locations
-       WRITE( ARRFile, *    ) Pos%nRZ,    Pos%RZ(    1 : Pos%nRZ )
-       WRITE( ARRFile, *    ) Pos%nRR,    Pos%RR(    1 : Pos%nRR )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( ARRFile, * ) Pos%nTheta, Pos%theta( 1 : Pos%nTheta )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
 
        ! IEsco22: add erays to arrivals output
@@ -641,6 +649,7 @@ CONTAINS
 # endif /* IHOP_THREED */
        ENDIF
 
+       ! IESCO25 Flush all files
        FLUSH( RAYFile )
        IF (writeDelay) FLUSH( DELFile )
        FLUSH( ARRFile )
@@ -652,26 +661,36 @@ CONTAINS
               FORM = 'FORMATTED' )
 
 # ifdef IHOP_THREED
-       WRITE( ARRFile, * ) '''3D'''
+       WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
-       WRITE( ARRFile, * ) '''2D'''
+       WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
 
-       WRITE( ARRFile, * ) IHOP_freq
+       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
        ! write source locations
 # ifdef IHOP_THREED
-       WRITE( ARRFile, * ) Pos%nSX,    Pos%SX(    1 : Pos%nSX )
-       WRITE( ARRFile, * ) Pos%nSY,    Pos%SY(    1 : Pos%nSY )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+# else /* IHOP_THREED */
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
-       WRITE( ARRFile, * ) Pos%nSZ,    Pos%SZ(    1 : Pos%nSZ )
 
        ! write receiver locations
-       WRITE( ARRFile, *    ) Pos%nRZ,    Pos%RZ(    1 : Pos%nRZ )
-       WRITE( ARRFile, *    ) Pos%nRR,    Pos%RR(    1 : Pos%nRR )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( ARRFile, * ) Pos%nTheta, Pos%theta( 1 : Pos%nTheta )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
+
        FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
     CASE ( 'a' )        ! arrival file in binary format
@@ -680,28 +699,36 @@ CONTAINS
               FORM = 'UNFORMATTED' )
 
 # ifdef IHOP_THREED
-       WRITE( ARRFile ) '''3D'''
+       WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
-       WRITE( ARRFile ) '''2D'''
+       WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
 
-       WRITE( ARRFile    ) SNGL( IHOP_freq )
+       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
        ! write source locations
 # ifdef IHOP_THREED
-       WRITE( ARRFile,*    ) Pos%nSX,    Pos%SX(    1 : Pos%nSX )
-       WRITE( ARRFile,*    ) Pos%nSY,    Pos%SY(    1 : Pos%nSY )
-       WRITE( ARRFile,*    ) Pos%nSZ,    Pos%SZ(    1 : Pos%nSZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # else /* IHOP_THREED */
-       WRITE( ARRFile,*    ) Pos%nSZ,    Pos%SZ(    1 : Pos%nSZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
 
        ! write receiver locations
-       WRITE( ARRFile,*       ) Pos%nRZ,    Pos%RZ(    1 : Pos%nRZ )
-       WRITE( ARRFile,*       ) Pos%nRR,    Pos%RR(    1 : Pos%nRR )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( ARRFile,*    ) Pos%nTheta, Pos%theta( 1 : Pos%nTheta )
+       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
+
        FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
 

--- a/src/ihop_init_mod.F90
+++ b/src/ihop_init_mod.F90
@@ -159,6 +159,10 @@ CONTAINS
     CALL ReadSXSY( myThid ) ! Read source/receiver x-y coordinates
 
     Pos%nSZ = IHOP_nsd
+    IF (Pos%nSZ .GE. 1) THEN
+        Pos%nSX = Pos%nSZ
+        Pos%nSY = Pos%nSZ
+    ENDIF
     Pos%nRZ = IHOP_nrd
 
     CALL AllocatePos( Pos%nSZ, Pos%SZ, IHOP_sd, myThid )

--- a/src/influence.F90
+++ b/src/influence.F90
@@ -571,26 +571,29 @@ CONTAINS
       CASE ( 'E' )                ! eigenrays
         U=U
         tmpDelay = 0.
-        CALL WriteRayOutput( RAYFile, iS, ray2D%x(1), ray2D%x(2), &
+        CALL WriteRayOutput( RAYFile, iS,           &
+            ray2D(1:iS)%x(1), ray2D(1:iS)%x(2),     &
             ray2D(iS)%NumTopBnc, ray2D(iS)%NumBotBnc )
       CASE ( 'e' )                ! eigenrays AND arrivals
         U=U
         tmpDelay = 0.
-        CALL WriteRayOutput( RAYFile, iS, ray2D%x(1), ray2D%x(2), &
+        CALL WriteRayOutput( RAYFile, iS,           &
+            ray2D(1:iS)%x(1), ray2D(1:iS)%x(2),     &
             ray2D(iS)%NumTopBnc, ray2D(iS)%NumBotBnc )
         IF (writeDelay) THEN
-          tmpDelay = REAL(ray2D%tau)
-          CALL WriteRayOutput( DELFile, iS, tmpDelay, ray2D%x(2), &
+          tmpDelay = REAL(ray2D(1:iS)%tau)
+          CALL WriteRayOutput( DELFile, iS,             &
+              tmpDelay, ray2D(1:iS)%x(2),               &
               ray2D(iS)%NumTopBnc, ray2D(iS)%NumBotBnc )
         END IF
 
-        CALL AddArr( afreq, iz, ir, Amp, phaseInt, delay, SrcDeclAngle, &
+        CALL AddArr( afreq, iz, ir, Amp, phaseInt, delay,  &
                      RcvrDeclAngle, ray2D( iS )%NumTopBnc, &
                      ray2D( iS )%NumBotBnc )
       CASE ( 'A', 'a' )           ! arrivals
         U=U
         tmpDelay = 0.
-        CALL AddArr( afreq, iz, ir, Amp, phaseInt, delay, SrcDeclAngle, &
+        CALL AddArr( afreq, iz, ir, Amp, phaseInt, delay,  &
                      RcvrDeclAngle, ray2D( iS )%NumTopBnc, &
                      ray2D( iS )%NumBotBnc )
       CASE ( 'C' )                ! coherent TL

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -48,7 +48,6 @@ CONTAINS
     INTEGER,           INTENT( IN ) :: funit, nSteps, tBnc, bBnc
     REAL (KIND=_RL90), INTENT( IN ) :: col1In(:), col2In(:)
     REAL (KIND=_RL90) :: col1(nSteps), col2(nSteps)
-    REAL (KIND=_RL90) :: alpha   ! take-off angle of this ray
 
     ! In adjoint mode we do not write output besides on the first run
     IF (IHOP_dumpfreq.LT.0) RETURN

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -46,8 +46,8 @@ CONTAINS
     USE bdry_mod, only: Bdry
 
     INTEGER,           INTENT( IN ) :: funit, nSteps, tBnc, bBnc
-    REAL (KIND=_RL90), INTENT( IN ) :: col1In(:), col2In(:)
-    REAL (KIND=_RL90) :: col1(nSteps), col2(nSteps)
+    REAL (KIND=_RL90), INTENT( IN ) :: col1In(nSteps), col2In(nSteps)
+    REAL (KIND=_RL90) :: col1(nSteps+1), col2(nSteps+1)
 
     ! In adjoint mode we do not write output besides on the first run
     IF (IHOP_dumpfreq.LT.0) RETURN
@@ -65,7 +65,7 @@ CONTAINS
       ! only for flat bdry)
       IF ( MIN( Bdry%Bot%HS%Depth - col2In( is ),  &
                 col2In( is ) - Bdry%Top%HS%Depth ) < 0.2 .OR. &
-           MOD( is, iSkip ) == 0 .OR. is == nSteps ) THEN
+           MOD( is, iSkip ) == 0 .OR. is==nSteps ) THEN
         N2 = N2 + 1
         col1(N2) = col1In(is)
         col2(N2) = col2In(is)

--- a/src/writeray.F90
+++ b/src/writeray.F90
@@ -70,9 +70,9 @@ CONTAINS
         col1(N2) = col1In(is)
         col2(N2) = col2In(is)
 
-      ELSE
-        col1(is) = col1In(is)
-        col2(is) = col2In(is)
+!      ELSE ! IESCO22 debugging
+!        col1(is) = col1In(is)
+!        col2(is) = col2In(is)
 
       END IF
     END DO Stepping


### PR DESCRIPTION
Previously, ascii file headers and diagnostics output was mostly written using wildcat formatting:
```
WRITE(fUnit, *) ...
```

Added formatting to ARRFile, RAYFile, and DELFile. Now, we do not see ASCII NUL characters in diagnostic output files