### PR TITLE
Allow for IO in MPI based runs

### DIFF
--- a/mitgcm_input/data.ihop
+++ b/mitgcm_input/data.ihop
@@ -26,7 +26,6 @@
 
  &IHOP_PARM03
  IHOP_interpfile = 'bcg_ihop-grid',
-#ihop_iter = 1,2,3,4,5,6,7,8,
  ihop_iter = 6,7,8,
 
  &

--- a/src/beampat.F90
+++ b/src/beampat.F90
@@ -112,26 +112,22 @@ CONTAINS
   _BEGIN_MASTER(myThid)
 
 #ifdef IHOP_WRITE_OUT
-  ! In adjoint mode we do not write output besides on the first run
-  IF (IHOP_dumpfreq.GE.0) THEN
+  IF ( SBPFlag == '*' ) THEN
+    WRITE( PRTFile, * )
+    WRITE( PRTFile, * ) '______________________________'
+    WRITE( PRTFile, * ) 'Using source beam pattern file'
+    
+    WRITE( PRTFile, * ) 'Number of source beam pattern points', NSBPPts
 
-    IF ( SBPFlag == '*' ) THEN
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) '______________________________'
-      WRITE( PRTFile, * ) 'Using source beam pattern file'
-      
-      WRITE( PRTFile, * ) 'Number of source beam pattern points', NSBPPts
+    WRITE( PRTFile, * )
+    WRITE( PRTFile, * ) ' Angle (degrees)  Power (dB)'
 
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) ' Angle (degrees)  Power (dB)'
-
-      DO I = 1, NSBPPts
-        WRITE( PRTFile, FMT = "( 2G11.3 )" ) SrcBmPat( I, : )
-      END DO
-    END IF
-
-  END IF ! don't write in adjoint mode
+    DO I = 1, NSBPPts
+      WRITE( PRTFile, FMT = "( 2G11.3 )" ) SrcBmPat( I, : )
+    END DO
+  END IF
 #endif /* IHOP_WRITE_OUT */
+
   ! I/O on main thread only
   _END_MASTER(myThid)
   _BARRIER

--- a/src/beampat.F90
+++ b/src/beampat.F90
@@ -24,9 +24,9 @@ MODULE beamPat
     public NSBPPts, SrcBmPat, SBPFlag, readPat, writePat
 !=======================================================================
 
-  INTEGER                    :: NSBPPts ! Number of source beam-pattern points
+  INTEGER       :: NSBPPts ! Number of source beam-pattern points
   REAL (KIND=_RL90), ALLOCATABLE :: SrcBmPat( :, : )
-  CHARACTER (LEN=1)          :: SBPFlag ! '*' or 'O' to indicate a directional or omni pattern
+  CHARACTER*(1) :: SBPFlag ! '*' or 'O' to indicate a directional or omni pattern
 
 CONTAINS
 ! **************************************************************************** !
@@ -44,24 +44,24 @@ CONTAINS
 
     IF (ALLOCATED(SrcBmPat)) DEALLOCATE(SrcBmPat)
 
-    IF ( SBPFlag == '*' ) THEN
-      OPEN( UNIT = SBPFile, FILE = TRIM( IHOP_fileroot ) // '.sbp', &
-            STATUS = 'OLD', IOSTAT = IOStat, ACTION = 'READ' )
-      IF ( IOStat /= 0 ) THEN
+    IF ( SBPFlag=='*' ) THEN
+      OPEN( UNIT=SBPFile, FILE=TRIM( IHOP_fileroot ) // '.sbp', &
+            STATUS='OLD', IOSTAT=IOStat, ACTION='READ' )
+      IF ( IOStat/=0 ) THEN
 #ifdef IHOP_WRITE_OUT
         ! In adjoint mode we do not write output besides on the first run
         IF (IHOP_dumpfreq.GE.0) &
-        WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
-                             'Unable to open source beampattern file'
+          WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
+                               'Unable to open source beampattern file'
         CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadPat'
       END IF
 
-      READ(  SBPFile, * ) NSBPPts
+      READ( SBPFile, * ) NSBPPts
 
-      ALLOCATE( SrcBmPat( NSBPPts, 2 ), Stat = IAllocStat )
-      IF ( IAllocStat /= 0 ) THEN
+      ALLOCATE( SrcBmPat( NSBPPts, 2 ), Stat=IAllocStat )
+      IF ( IAllocStat/=0 ) THEN
 #ifdef IHOP_WRITE_OUT
         WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
         'Insufficient memory for beam pattern data: reduce # SBP points'
@@ -71,7 +71,7 @@ CONTAINS
       END IF
 
       DO I = 1, NSBPPts
-        READ(  SBPFile, * ) SrcBmPat( I, : )
+        READ( SBPFile, * ) SrcBmPat( I, : )
       END DO
 
     ELSE   ! no pattern given, use omni source pattern

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -146,9 +146,9 @@ CONTAINS
             CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
             CLOSE(PRTFile)
 
-          ENDIF ! IF ( myProcId.GT.0) 
+          ENDIF ! IF ( myProcId.GT.0)
         ENDIF ! IF ( numberOfProcs.GT.1 )
-# endif /* ALLOW_USE_MPI */ 
+# endif /* ALLOW_USE_MPI */
       ENDIF
 
       ! close all files

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -756,10 +756,10 @@ CONTAINS
     RN = 2 * kappa / c ** 2 / Th    ! boundary curvature correction
 
     IF ( BotTop == 'TOP' ) THEN
-       ! cnjump changes sign because the (t,n) system of the top boundary has a
-       ! different sense to the bottom boundary
-       cnjump = -cnjump
-       RN     = -RN
+      ! cnjump changes sign because the (t,n) system of the top boundary has a
+      ! different sense to the bottom boundary
+      cnjump = -cnjump
+      RN     = -RN
     END IF
 
     RM = Tg / Th   ! this is tan( alpha ) where alpha is the angle of incidence
@@ -767,11 +767,11 @@ CONTAINS
 
     SELECT CASE ( Beam%Type( 3:3 ) )
     CASE ( 'D' )
-       RN = 2.0 * RN
+      RN = 2.0 * RN
     CASE ( 'Z' )
-       RN = 0.0
+      RN = 0.0
     CASE DEFAULT
-       RN = RN
+      RN = RN
     END SELECT
 
     ray2D( is1 )%c   = c
@@ -784,136 +784,138 @@ CONTAINS
 
     SELECT CASE ( HS%BC )
     CASE ( 'R' )                 ! rigid
-       ray2D( is1 )%Amp   = ray2D( is )%Amp
-       ray2D( is1 )%Phase = ray2D( is )%Phase
+      ray2D( is1 )%Amp   = ray2D( is )%Amp
+      ray2D( is1 )%Phase = ray2D( is )%Phase
     CASE ( 'V' )                 ! vacuum
-       ray2D( is1 )%Amp   = ray2D( is )%Amp
-       ray2D( is1 )%Phase = ray2D( is )%Phase + PI
+      ray2D( is1 )%Amp   = ray2D( is )%Amp
+      ray2D( is1 )%Phase = ray2D( is )%Phase + PI
     CASE ( 'F' )                 ! file
 !$TAF store rint = reflect2d1
-       ! angle of incidence (relative to normal to bathymetry)
-       IF ( (Th==0.0) .AND. (Tg==0.0) ) THEN
-          RInt%theta = 0.0
-       ELSE
-          RInt%theta = rad2deg * ABS( ATAN2( Th, Tg ) )
-       ENDIF
-       
-       ! reflection coefficient is symmetric about 90 degrees
-       IF ( RInt%theta > 90 ) RInt%theta = 180. - RInt%theta 
+      ! angle of incidence (relative to normal to bathymetry)
+      IF ( (Th==0.0) .AND. (Tg==0.0) ) THEN
+        RInt%theta = 0.0
+      ELSE
+        RInt%theta = rad2deg * ABS( ATAN2( Th, Tg ) )
+      ENDIF
+      
+      ! reflection coefficient is symmetric about 90 degrees
+      IF ( RInt%theta > 90 ) RInt%theta = 180. - RInt%theta 
 
-       CALL InterpolateReflectionCoefficient( RInt, RefC, Npts )
-       ray2D( is1 )%Amp   = ray2D( is )%Amp * RInt%R
-       ray2D( is1 )%Phase = ray2D( is )%Phase + RInt%phi
+      CALL InterpolateReflectionCoefficient( RInt, RefC, Npts )
+      ray2D( is1 )%Amp   = ray2D( is )%Amp * RInt%R
+      ray2D( is1 )%Phase = ray2D( is )%Phase + RInt%phi
 
     CASE ( 'A', 'G' )     ! half-space
-       kx = afreq * Tg    ! wavenumber in direction parallel      to bathymetry
-       kz = afreq * Th    ! wavenumber in direction perpendicular to bathymetry
+      kx = afreq * Tg    ! wavenumber in direction parallel      to bathymetry
+      kz = afreq * Th    ! wavenumber in direction perpendicular to bathymetry
 
-       ! notation below is a bit mis-leading
-       ! kzS, kzP is really what I called gamma in other codes, and differs by a
-       ! factor of +/- i
-       IF ( REAL( HS%cS ) > 0.0 ) THEN
-          kzS2 = kx**2 - ( afreq / HS%cS )**2
-          kzP2 = kx**2 - ( afreq / HS%cP )**2
-          kzS  = SQRT( kzS2 )
-          kzP  = SQRT( kzP2 )
-          mu   = HS%rho * HS%cS**2
+      ! notation below is a bit mis-leading
+      ! kzS, kzP is really what I called gamma in other codes, and differs by a
+      ! factor of +/- i
+      IF ( REAL( HS%cS ) > 0.0 ) THEN
+        kzS2 = kx**2 - ( afreq / HS%cS )**2
+        kzP2 = kx**2 - ( afreq / HS%cP )**2
+        kzS  = SQRT( kzS2 )
+        kzP  = SQRT( kzP2 )
+        mu   = HS%rho * HS%cS**2
 
-          y2 = ( ( kzS2 + kx**2 )**2 - 4.0D0 * kzS * kzP * kx**2 ) * mu
-          y4 = kzP * ( kx**2 - kzS2 )
+        y2 = ( ( kzS2 + kx**2 )**2 - 4.0D0 * kzS * kzP * kx**2 ) * mu
+        y4 = kzP * ( kx**2 - kzS2 )
 
-          f = afreq**2 * y4
-          g = y2
-       ELSE
-          kzP = SQRT( kx**2 - ( afreq / HS%cP )**2 )
+        f = afreq**2 * y4
+        g = y2
+      ELSE
+        kzP = SQRT( kx**2 - ( afreq / HS%cP )**2 )
 
-          ! Intel and GFortran compilers return different branches of the SQRT
-          ! for negative reals
-          IF ( REAL( kzP ) == 0.0D0 .AND. AIMAG( kzP ) < 0.0D0 ) kzP = -kzP
-          f   = kzP
-          g   = HS%rho
-       ENDIF
+        ! Intel and GFortran compilers return different branches of the SQRT
+        ! for negative reals
+        IF ( REAL( kzP ) == 0.0D0 .AND. AIMAG( kzP ) < 0.0D0 ) kzP = -kzP
+        f   = kzP
+        g   = HS%rho
+      ENDIF
 
-       ! complex reflection coef.
-       Refl =  - ( rho*f - oneCMPLX * kz*g ) / ( rho*f + oneCMPLX*kz*g )
+      ! complex reflection coef.
+      Refl =  - ( rho*f - oneCMPLX * kz*g ) / ( rho*f + oneCMPLX*kz*g )
 
-       IF ( ABS( Refl ) < 1.0E-5 ) THEN   ! kill a ray that has lost its energy in reflection
-          ray2D( is1 )%Amp   = 0.0
-          ray2D( is1 )%Phase = ray2D( is )%Phase
-       ELSE
-          ray2D( is1 )%Amp   = ABS( Refl ) * ray2D(  is )%Amp
-          ray2D( is1 )%Phase = ray2D( is )%Phase + &
-                               ATAN2( AIMAG( Refl ), REAL( Refl ) )
+      IF ( ABS( Refl ) < 1.0E-5 ) THEN   ! kill a ray that has lost its energy in reflection
+        ray2D( is1 )%Amp   = 0.0
+        ray2D( is1 )%Phase = ray2D( is )%Phase
+      ELSE
+        ray2D( is1 )%Amp   = ABS( Refl ) * ray2D(  is )%Amp
+        ray2D( is1 )%Phase = ray2D( is )%Phase + &
+                             ATAN2( AIMAG( Refl ), REAL( Refl ) )
 
-          if ( Beam%Type( 4:4 ) == 'S' ) then   ! beam displacement & width change (Seongil's version)
-             ch = ray2D( is )%c / conjg( HS%cP )
-             co = ray2D( is )%t( 1 ) * ray2D( is )%c
-             si = ray2D( is )%t( 2 ) * ray2D( is )%c
-             ck = afreq / ray2D( is )%c
+        IF ( Beam%Type( 4:4 ) == 'S' ) THEN   ! beam displacement & width change (Seongil's version)
+          ch = ray2D( is )%c / conjg( HS%cP )
+          co = ray2D( is )%t( 1 ) * ray2D( is )%c
+          si = ray2D( is )%t( 2 ) * ray2D( is )%c
+          ck = afreq / ray2D( is )%c
 
-             a   = 2 * HS%rho * ( 1 - ch * ch )
-             b   = co * co - ch * ch
-             d   = HS%rho * HS%rho * si * si + b
-             sb  = sqrt( b )
-             cco = co * co
-             ssi = si * si
+          a   = 2 * HS%rho * ( 1 - ch * ch )
+          b   = co * co - ch * ch
+          d   = HS%rho * HS%rho * si * si + b
+          sb  = sqrt( b )
+          cco = co * co
+          ssi = si * si
 
-             IF ( si /= 0.0 ) THEN
-                delta = a * co / si / ( ck * sb * d )   ! Do we need an abs() on this???
-             ELSE
-                delta = 0.0
-             END IF
+          IF ( si /= 0.0 ) THEN
+             delta = a * co / si / ( ck * sb * d )   ! Do we need an abs() on this???
+          ELSE
+             delta = 0.0
+          ENDIF
 
-             pdelta  = real( delta ) / ( ray2D( is )%c / co)
-             ddelta  = -a / ( ck*sb*d ) - a*cco / ssi / (ck*sb*d) &
-                       + a*cco / (ck*b*sb*d) &
-                       -a*co / si / (ck*sb*d*d) &
-                       * (2* HS%rho * HS%rho *si*co-2*co*si)
-             rddelta = -real( ddelta )
-             sddelta = rddelta / abs( rddelta )
+          pdelta  = real( delta ) / ( ray2D( is )%c / co)
+          ddelta  = -a / ( ck*sb*d ) - a*cco / ssi / (ck*sb*d) &
+                    + a*cco / (ck*b*sb*d) &
+                    -a*co / si / (ck*sb*d*d) &
+                    * (2* HS%rho * HS%rho *si*co-2*co*si)
+          rddelta = -real( ddelta )
+          sddelta = rddelta / abs( rddelta )
 
-             ! next 3 lines have an update by Diana McCammon to allow a sloping
-             ! bottom . I think the formulas are good, but this won't be reliable
-             ! because it doesn't have the logic that tracks crossing into new
-             ! segments after the ray displacement.
+          ! next 3 lines have an update by Diana McCammon to allow a sloping
+          ! bottom . I think the formulas are good, but this won't be reliable
+          ! because it doesn't have the logic that tracks crossing into new
+          ! segments after the ray displacement.
 
-             theta_bot = datan( tBdry( 2 ) / tBdry( 1 ))  ! bottom angle
-             ray2D( is1 )%x( 1 ) = ray2D( is1 )%x( 1 ) + real( delta ) &
-                                   * dcos( theta_bot )   ! range displacement
-             ray2D( is1 )%x( 2 ) = ray2D( is1 )%x( 2 ) + real( delta ) &
-                                   * dsin( theta_bot )   ! depth displacement
-             ray2D( is1 )%tau    = ray2D( is1 )%tau + pdelta  ! phase change
-             ray2D( is1 )%q      = ray2D( is1 )%q + sddelta * rddelta * si * c &
-                                   * ray2D( is )%p   ! beam-width change
-          endif
+          theta_bot = datan( tBdry( 2 ) / tBdry( 1 ))  ! bottom angle
+          ray2D( is1 )%x( 1 ) = ray2D( is1 )%x( 1 ) + real( delta ) &
+                                * dcos( theta_bot )   ! range displacement
+          ray2D( is1 )%x( 2 ) = ray2D( is1 )%x( 2 ) + real( delta ) &
+                                * dsin( theta_bot )   ! depth displacement
+          ray2D( is1 )%tau    = ray2D( is1 )%tau + pdelta  ! phase change
+          ray2D( is1 )%q      = ray2D( is1 )%q + sddelta * rddelta * si * c &
+                                * ray2D( is )%p   ! beam-width change
+                            
+        ENDIF
 
-       ENDIF
+      ENDIF
 
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(2A)') 'HS%BC = ', HS%BC
-       ! In adjoint mode we do not write output besides on the first run
-       IF (IHOP_dumpfreq.GE.0) &
+      WRITE(msgBuf,'(2A)') 'HS%BC = ', HS%BC
+      ! In adjoint mode we do not write output besides on the first run
+      IF ( IHOP_dumpfreq.GE.0 ) &
         CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
-       WRITE(msgBuf,'(A)') 'IHOP Reflect2D: Unknown boundary condition type'
-       CALL PRINT_ERROR( msgBuf,myThid )
+      WRITE(msgBuf,'(A)') 'IHOP Reflect2D: Unknown boundary condition type'
+      CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
        STOP 'ABNORMAL END: S/R Reflect2D'
     END SELECT
 
     ! Update top/bottom bounce counter
     IF (BotTop == 'TOP') THEN
-       ray2D( is+1 )%NumTopBnc = ray2D( is )%NumTopBnc + 1
-    ELSE IF ( BotTop == 'BOT' ) THEN
-       ray2D( is+1 )%NumBotBnc = ray2D( is )%NumBotBnc + 1
+      ray2D( is+1 )%NumTopBnc = ray2D( is )%NumTopBnc + 1
+    ELSEIF ( BotTop == 'BOT' ) THEN
+      ray2D( is+1 )%NumBotBnc = ray2D( is )%NumBotBnc + 1
     ELSE
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(2A)') 'IHOP Reflect2D: ', &
-                            'no reflection bounce, but in reflect2d somehow'
-       CALL PRINT_ERROR( msgBuf,myThid )
+      WRITE(msgBuf,'(2A)') 'IHOP Reflect2D: ', &
+                           'no reflection bounce, but in reflect2d somehow'
+      CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-       STOP 'ABNORMAL END: S/R Reflect2D'
-    END IF
+      STOP 'ABNORMAL END: S/R Reflect2D'
+      
+    ENDIF
 
   RETURN
   END !SUBROUTINE Reflect2D

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -140,10 +140,10 @@ CONTAINS
       CALL CPU_TIME( Tstart )
       CALL IHOPCore( myThid )
       CALL CPU_TIME( Tstop  )
-#ifdef ALLOW_USE_MPI
-      IF ( usingMPI ) CALL MPI_BARRIER(MPI_COMM_WORLD, mpiRC)
-#endif
     ENDIF ! IF ( myProcId.EQ.0 )
+#ifdef ALLOW_USE_MPI
+    IF ( usingMPI ) CALL MPI_BARRIER(MPI_COMM_WORLD, mpiRC)
+#endif
 
 #ifdef IHOP_WRITE_OUT
     IF (( myProcId.EQ.0 ) .AND. ( IHOP_dumpfreq.GE.0 )) THEN

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -627,6 +627,7 @@ CONTAINS
             endRay=.TRUE.
           ELSE
             WRITE(msgBuf,'(A)')
+            endRay=.FALSE.
           ENDIF
 
 #ifdef IHOP_WRITE_OUT

--- a/src/ihop.F90
+++ b/src/ihop.F90
@@ -84,6 +84,13 @@ CONTAINS
     ! Reset memory and default values: REQUIRED
     CALL resetMemory()
 
+    ! Only do IO and computation on a single process!
+#ifdef ALLOW_USE_MPI
+    IF ( usingMPI ) THEN
+
+    ENDIF ! IF ( usingMPI )
+#endif ALLOW_USE_MPI
+
     ! save data.ihop, open PRTFile: REQUIRED
     CALL initPRTFile( myTime, myIter, myThid )
 
@@ -96,14 +103,15 @@ CONTAINS
     ! Source Beam Pattern: OPTIONAL, default is omni source pattern
     CALL writePat( myThid )
 
+    ! open output files: only on first adjoint forward pass
+    IF ( IHOP_dumpfreq.GE.0 ) &
+      CALL OpenOutputFiles( IHOP_fileroot, myTime, myIter, myThid )
+
 
     ! set SSP%cmat from gcm SSP: REQUIRED
     CALL setSSP( myThid )
 
 
-! open output files: only on first adjoint forward pass
-    IF ( IHOP_dumpfreq.GE.0 ) &
-      CALL OpenOutputFiles( IHOP_fileroot, myTime, myIter, myThid )
 
     ! Run IHOP solver on a single processor
     IF ( numberOfProcs.GT.1 ) THEN

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -105,9 +105,9 @@ CONTAINS
       CALL WriteSxSy( myThid )
       CALL WriteSzRz( myThid )
       CALL WriteRcvrRanges( myThid )
-#ifdef IHOP_THREED
+# ifdef IHOP_THREED
       CALL WriteRcvrBearings( myThid )
-#endif
+# endif
       CALL WriteFreqVec( Bdry%Top%HS%Opt( 6:6 ), myThid )
 
 
@@ -151,7 +151,7 @@ CONTAINS
       WRITE(msgBuf,'(A)')
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
-#ifdef IHOP_THREED
+# ifdef IHOP_THREED
       WRITE(msgBuf,'(A,G11.6,A)') &
           ' Maximum ray x-range, Box%X = ', Beam%Box%X,' m'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -161,7 +161,7 @@ CONTAINS
       WRITE(msgBuf,'(A,G11.6,A)') &
           ' Maximum ray z-range, Box%Z = ', Beam%Box%Z,' m'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-#else /* not IHOP_THREED */
+# else /* not IHOP_THREED */
       ranges = Beam%Box%R / 1000.0
       WRITE(msgBuf,'(A,G11.6,A)') &
           ' Maximum ray range, Box%R = ', ranges,' km'
@@ -169,7 +169,7 @@ CONTAINS
       WRITE(msgBuf,'(A,G11.6,A)') &
           ' Maximum ray depth, Box%Z = ', Beam%Box%Z,' m'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-#endif /* not IHOP_THREED */
+# endif /* not IHOP_THREED */
 
       SELECT CASE ( Beam%Type( 4:4 ) )
       CASE ( 'S' )
@@ -203,7 +203,7 @@ CONTAINS
   !     msgBuf :: Used to build messages for printing.
     _RL, INTENT(IN)     ::  myTime
     INTEGER, INTENT(IN) ::  myIter, myThid
-    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+    CHARACTER*(MAX_LEN_MBUF) :: msgBuf
 
 
   !     == Local Arguments ==

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -668,15 +668,14 @@ CONTAINS
       WRITE( RAYFile, '(I)'     ) Angles%nAlpha
       WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
       WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
-
 #ifdef IHOP_THREED
       WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
       WRITE( RAYFile, '(A)'  ) '''xyz'''
 #else /* IHOP_THREED */
       WRITE( RAYFile, '(A)'  ) '''rz'''
 #endif /* IHOP_THREED */
-      FLUSH( RAYFile )
 
+      FLUSH( RAYFile )
 #endif /* IHOP_WRITE_OUT */
 
       IF (writeDelay) THEN
@@ -690,14 +689,15 @@ CONTAINS
         WRITE( DELFile, '(I)'     ) Angles%nAlpha
         WRITE( DELFile, '(F10.4)' ) Bdry%Top%HS%Depth
         WRITE( DELFile, '(F10.4)' ) Bdry%Bot%HS%Depth
-
 #ifdef IHOP_THREED
         WRITE( DELFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
         WRITE( DELFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
         WRITE( DELFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
+
         FLUSH( DELFile )
+
       ENDIF
 
     CASE ( 'e' ) ! eigenrays + arrival file in ascii format
@@ -706,13 +706,11 @@ CONTAINS
       IF (isOpen) CLOSE(ARRFile)
       OPEN ( FILE=TRIM( fullName ) // '.arr', UNIT=ARRFile, &
              FORM='FORMATTED' )
-
 # ifdef IHOP_THREED
       WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
       WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
-
       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
       ! write source locations
@@ -737,6 +735,7 @@ CONTAINS
       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
+
       FLUSH( ARRFile )
 
       ! IEsco22: add erays to arrivals output
@@ -750,13 +749,13 @@ CONTAINS
       WRITE( RAYFile, '(I)'     ) Angles%nAlpha
       WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
       WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
-
 # ifdef IHOP_THREED
       WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
       WRITE( RAYFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
       WRITE( RAYFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
+
       FLUSH( RAYFile )
 
       IF (writeDelay) THEN
@@ -770,16 +769,16 @@ CONTAINS
         WRITE( DELFile, '(I)'     ) Angles%nAlpha
         WRITE( DELFile, '(F10.4)' ) Bdry%Top%HS%Depth
         WRITE( DELFile, '(F10.4)' ) Bdry%Bot%HS%Depth
-
 #ifdef IHOP_THREED
         WRITE( DELFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
         WRITE( DELFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
         WRITE( DELFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
-        FLUSH( DELFile )
-      ENDIF
 
+        FLUSH( DELFile )
+
+      ENDIF
 #endif /* IHOP_WRITE_OUT */
 
     CASE ( 'A' )        ! arrival file in ascii format
@@ -794,7 +793,6 @@ CONTAINS
 # else /* IHOP_THREED */
       WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
-
       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
       ! write source locations
@@ -835,7 +833,6 @@ CONTAINS
 # else /* IHOP_THREED */
       WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
-
       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
       ! write source locations

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -229,15 +229,12 @@ CONTAINS
       WRITE(myProcessStr,fmtStr) myProcId
       IL = ILNBLNK( myProcessStr )
       mpiPidIo = myProcId
-      pidIO    = mpiPidIo
 
       IF( mpiPidIo.EQ.myProcId ) THEN
-#  ifdef SINGLE_DISK_IO
-        IF( myProcId.EQ.0 ) THEN
-#  endif
+
         IF ( myIter.GE.0 ) THEN
-          WRITE(fNam,'(4A,I10.10,A)') &
-            TRIM(IHOP_fileroot),'.',myProcessStr(1:IL),'.',myIter,'.prt'
+          WRITE(fNam,'(2A,I10.10,A)') &
+            TRIM(IHOP_fileroot),'.',myIter,'.prt'
         ELSE
           WRITE(fNam,'(4A)') &
             TRIM(IHOP_fileroot),'.',myProcessStr(1:IL),'.prt'
@@ -252,9 +249,7 @@ CONTAINS
           CALL PRINT_ERROR( msgBuf, myThid )
           STOP 'ABNORMAL END: S/R IHOP_INIT'
         END IF
-#  ifdef SINGLE_DISK_IO
-        END IF
-#  endif
+
       END IF
 # endif /* ALLOW_USE_MPI */
     END IF

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -438,7 +438,7 @@ CONTAINS
   !**********************************************************************!
 
   SUBROUTINE WriteBdry( HS, myThid )
-    USE ihop_mod,  only: PRTFile
+    USE ihop_mod,only: PRTFile
     USE ssp_mod, only: rhoR, alphaR, betaR, alphaI, betaI
 
     ! Handles top and bottom boundary conditions
@@ -507,11 +507,11 @@ CONTAINS
   ! **********************************************************************!
 
   SUBROUTINE openOutputFiles( fName, myTime, myIter, myThid )
-    USE ihop_mod,  only: RAYFile, DELFile, ARRFile, SHDFile, Title, Beam
+    USE ihop_mod,  only: RAYFile, DELFile, ARRFile, SHDFile, & 
+                         Title, Beam
+    USE angle_mod, only: Angles
+    USE srPos_mod, only: Pos
     ! Write appropriate header information
-
-    USE angle_mod,  only: Angles
-    USE srPos_mod,  only: Pos
 
     ! == Routine Arguments ==
     !  myTime   :: Current time in simulation
@@ -523,245 +523,245 @@ CONTAINS
     ! == Local variables ==
     CHARACTER*(MAX_LEN_FNAM), INTENT(IN) :: fName
     CHARACTER*(MAX_LEN_FNAM) :: fullName
-    INTEGER             :: IL
-    REAL               :: atten
-    CHARACTER (LEN=10) :: PlotType
-    CHARACTER (LEN=20) :: fmtstr
-    LOGICAL :: isOpen
+    CHARACTER*(10) :: PlotType
+    CHARACTER*(20) :: fmtstr
+    INTEGER        :: IL
+    REAL           :: atten
+    LOGICAL        :: isOpen
 
-    ! add time step to filename
     IF (myIter.GE.0) THEN
-        IL=ILNBLNK( fName )
-        WRITE(fullName, '(2A,I10.10)') fName(1:IL),'.',myIter
+      ! add time step to filename
+      IL=ILNBLNK( fName )
+      WRITE(fullName, '(2A,I10.10)') fName( 1:IL ), '.', myIter
     ELSE
-        fullName = fName
+      fullName = fName
     ENDIF
 
     SELECT CASE ( Beam%RunType( 1:1 ) )
     CASE ( 'R', 'E' )   ! Ray trace or Eigenrays
 #ifdef IHOP_WRITE_OUT
-       INQUIRE(UNIT=RAYFile, OPENED=isOpen)
-       IF (isOpen) CLOSE(RAYFile)
-       OPEN ( FILE = TRIM( fullName ) // '.ray', UNIT = RAYFile, &
-              FORM = 'FORMATTED' )
-       WRITE( RAYFile, '(3A)' )    '''', Title( 1:50 ), ''''
-       WRITE( RAYFile, '(F10.3)' ) IHOP_freq
-       WRITE( RAYFile, '(3I6)' )   Pos%nSX, Pos%nSY, Pos%nSZ
-       WRITE( RAYFile, '(I)' )     Angles%nAlpha
-       WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
-       WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
+      INQUIRE(UNIT=RAYFile, OPENED=isOpen)
+      IF (isOpen) CLOSE(RAYFile)
+      OPEN ( FILE=TRIM( fullName ) // '.ray', UNIT=RAYFile, &
+             FORM='FORMATTED' )
+      WRITE( RAYFile, '(3A)'    ) '''', Title( 1:50 ), ''''
+      WRITE( RAYFile, '(F10.3)' ) IHOP_freq
+      WRITE( RAYFile, '(3I6)'   ) Pos%nSX, Pos%nSY, Pos%nSZ
+      WRITE( RAYFile, '(I)'     ) Angles%nAlpha
+      WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
+      WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
 
 #ifdef IHOP_THREED
-       WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
-       WRITE( RAYFile, '(A)' ) '''xyz'''
+      WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
+      WRITE( RAYFile, '(A)'  ) '''xyz'''
 #else /* IHOP_THREED */
-       WRITE( RAYFile, '(A)' ) '''rz'''
+      WRITE( RAYFile, '(A)'  ) '''rz'''
 #endif /* IHOP_THREED */
-       FLUSH( RAYFile )
+      FLUSH( RAYFile )
 
 #endif /* IHOP_WRITE_OUT */
 
-       IF (writeDelay) THEN
+      IF (writeDelay) THEN
         INQUIRE(UNIT=DELFile, OPENED=isOpen)
         IF (isOpen) CLOSE(DELFile)
-        OPEN ( FILE = TRIM( fullName ) // '.delay', UNIT = DELFile, &
-               FORM = 'FORMATTED' )
-        WRITE( DELFile, '(3A)' )    '''', Title( 1:50 ), ''''
+        OPEN ( FILE=TRIM( fullName ) // '.delay', UNIT=DELFile, &
+               FORM='FORMATTED' )
+        WRITE( DELFile, '(3A)'    ) '''', Title( 1:50 ), ''''
         WRITE( DELFile, '(F10.3)' ) IHOP_freq
-        WRITE( DELFile, '(3I6)' )   Pos%nSX, Pos%nSY, Pos%nSZ
-        WRITE( DELFile, '(I)' )     Angles%nAlpha
+        WRITE( DELFile, '(3I6)'   ) Pos%nSX, Pos%nSY, Pos%nSZ
+        WRITE( DELFile, '(I)'     ) Angles%nAlpha
         WRITE( DELFile, '(F10.4)' ) Bdry%Top%HS%Depth
         WRITE( DELFile, '(F10.4)' ) Bdry%Bot%HS%Depth
 
 #ifdef IHOP_THREED
         WRITE( DELFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
-        WRITE( DELFile, '(A)' ) '''xyz'''
+        WRITE( DELFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
-        WRITE( DELFile, '(A)' ) '''rz'''
+        WRITE( DELFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
         FLUSH( DELFile )
-       ENDIF
+      ENDIF
 
-    CASE ( 'e' )        ! eigenrays + arrival file in ascii format
+    CASE ( 'e' ) ! eigenrays + arrival file in ascii format
 #ifdef IHOP_WRITE_OUT
-       INQUIRE(UNIT=ARRFile, OPENED=isOpen)
-       IF (isOpen) CLOSE(ARRFile)
-       OPEN ( FILE = TRIM( fullName ) // '.arr', UNIT = ARRFile, &
-              FORM = 'FORMATTED' )
+      INQUIRE(UNIT=ARRFile, OPENED=isOpen)
+      IF (isOpen) CLOSE(ARRFile)
+      OPEN ( FILE=TRIM( fullName ) // '.arr', UNIT=ARRFile, &
+             FORM='FORMATTED' )
 
 # ifdef IHOP_THREED
-       WRITE( ARRFile, '(A)' ) '''3D'''
+      WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
-       WRITE( ARRFile, '(A)' ) '''2D'''
+      WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
 
-       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
+      WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
-       ! write source locations
+      ! write source locations
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # else /* IHOP_THREED */
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
 
-       ! write receiver locations
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
+      ! write receiver locations
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
-       FLUSH( ARRFile )
+      FLUSH( ARRFile )
 
-       ! IEsco22: add erays to arrivals output
-       INQUIRE(UNIT=RAYFile, OPENED=isOpen)
-       IF (isOpen) CLOSE(RAYFile)
-       OPEN ( FILE = TRIM( fullName ) // '.ray', UNIT = RAYFile, &
-              FORM = 'FORMATTED' )
-       WRITE( RAYFile, '(3A)' )    '''', Title( 1:50 ), ''''
-       WRITE( RAYFile, '(F10.3)' ) IHOP_freq
-       WRITE( RAYFile, '(3I6)' )   Pos%nSX, Pos%nSY, Pos%nSZ
-       WRITE( RAYFile, '(I)' )     Angles%nAlpha
-       WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
-       WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
+      ! IEsco22: add erays to arrivals output
+      INQUIRE(UNIT=RAYFile, OPENED=isOpen)
+      IF (isOpen) CLOSE(RAYFile)
+      OPEN ( FILE=TRIM( fullName ) // '.ray', UNIT=RAYFile, &
+             FORM='FORMATTED' )
+      WRITE( RAYFile, '(3A)'    ) '''', Title( 1:50 ), ''''
+      WRITE( RAYFile, '(F10.3)' ) IHOP_freq
+      WRITE( RAYFile, '(3I6)'   ) Pos%nSX, Pos%nSY, Pos%nSZ
+      WRITE( RAYFile, '(I)'     ) Angles%nAlpha
+      WRITE( RAYFile, '(F10.4)' ) Bdry%Top%HS%Depth
+      WRITE( RAYFile, '(F10.4)' ) Bdry%Bot%HS%Depth
 
 # ifdef IHOP_THREED
-       WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
-       WRITE( RAYFile, '(A)' ) '''xyz'''
+      WRITE( RAYFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
+      WRITE( RAYFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
-       WRITE( RAYFile, '(A)' ) '''rz'''
+      WRITE( RAYFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
-       FLUSH( RAYFile )
+      FLUSH( RAYFile )
 
-       IF (writeDelay) THEN
+      IF (writeDelay) THEN
         INQUIRE(UNIT=DELFile, OPENED=isOpen)
         IF (isOpen) CLOSE(DELFile)
-        OPEN ( FILE = TRIM( fullName ) // '.delay', UNIT = DELFile, &
-               FORM = 'FORMATTED' )
-        WRITE( DELFile, '(3A)' )    '''', Title( 1:50 ), ''''
+        OPEN ( FILE=TRIM( fullName ) // '.delay', UNIT=DELFile, &
+               FORM='FORMATTED' )
+        WRITE( DELFile, '(3A)'    ) '''', Title( 1:50 ), ''''
         WRITE( DELFile, '(F10.3)' ) IHOP_freq
-        WRITE( DELFile, '(3I6)' )   Pos%nSX, Pos%nSY, Pos%nSZ
-        WRITE( DELFile, '(I)' )     Angles%nAlpha
+        WRITE( DELFile, '(3I6)'   ) Pos%nSX, Pos%nSY, Pos%nSZ
+        WRITE( DELFile, '(I)'     ) Angles%nAlpha
         WRITE( DELFile, '(F10.4)' ) Bdry%Top%HS%Depth
         WRITE( DELFile, '(F10.4)' ) Bdry%Bot%HS%Depth
 
 #ifdef IHOP_THREED
         WRITE( DELFile, '(2I)' ) Angles%nAlpha, Angles%nBeta
-        WRITE( DELFile, '(A)' ) '''xyz'''
+        WRITE( DELFile, '(A)'  ) '''xyz'''
 # else /* IHOP_THREED */
-        WRITE( DELFile, '(A)' ) '''rz'''
+        WRITE( DELFile, '(A)'  ) '''rz'''
 # endif /* IHOP_THREED */
         FLUSH( DELFile )
-       ENDIF
+      ENDIF
 
 #endif /* IHOP_WRITE_OUT */
 
     CASE ( 'A' )        ! arrival file in ascii format
 #ifdef IHOP_WRITE_OUT
-       INQUIRE(UNIT=ARRFile, OPENED=isOpen)
-       IF (isOpen) CLOSE(ARRFile)
-       OPEN ( FILE = TRIM( fullName ) // '.arr', UNIT = ARRFile, &
-              FORM = 'FORMATTED' )
+      INQUIRE(UNIT=ARRFile, OPENED=isOpen)
+      IF (isOpen) CLOSE(ARRFile)
+      OPEN ( FILE=TRIM( fullName ) // '.arr', UNIT=ARRFile, &
+             FORM='FORMATTED' )
 
 # ifdef IHOP_THREED
-       WRITE( ARRFile, '(A)' ) '''3D'''
+      WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
-       WRITE( ARRFile, '(A)' ) '''2D'''
+      WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
 
-       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
+      WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
-       ! write source locations
+      ! write source locations
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # else /* IHOP_THREED */
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
 
-       ! write receiver locations
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
+      ! write receiver locations
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
 
-       FLUSH( ARRFile )
+      FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
 
     CASE ( 'a' )        ! arrival file in binary format
 #ifdef IHOP_WRITE_OUT
-       INQUIRE(UNIT=ARRFile, OPENED=isOpen)
-       IF (isOpen) CLOSE(ARRFile)
-       OPEN ( FILE = TRIM( fullName ) // '.arr', UNIT = ARRFile, &
-              FORM = 'UNFORMATTED' )
+      INQUIRE(UNIT=ARRFile, OPENED=isOpen)
+      IF (isOpen) CLOSE(ARRFile)
+      OPEN ( FILE=TRIM( fullName ) // '.arr', UNIT=ARRFile, &
+             FORM='UNFORMATTED' )
 
 # ifdef IHOP_THREED
-       WRITE( ARRFile, '(A)' ) '''3D'''
+      WRITE( ARRFile, '(A)' ) '''3D'''
 # else /* IHOP_THREED */
-       WRITE( ARRFile, '(A)' ) '''2D'''
+      WRITE( ARRFile, '(A)' ) '''2D'''
 # endif /* IHOP_THREED */
 
-       WRITE( ARRFile, '(F10.4)' ) IHOP_freq
+      WRITE( ARRFile, '(F10.4)' ) IHOP_freq
 
-       ! write source locations
+      ! write source locations
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSX, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSX, Pos%SX( 1:Pos%nSX )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSY, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSY, Pos%SY( 1:Pos%nSY )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # else /* IHOP_THREED */
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nSZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nSZ, Pos%SZ( 1:Pos%nSZ )
 # endif /* IHOP_THREED */
 
-       ! write receiver locations
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
+      ! write receiver locations
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRZ, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRZ, Pos%RZ( 1:Pos%nRZ )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nRR, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nRR, Pos%RR( 1:Pos%nRR )
 # ifdef IHOP_THREED
-       WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
-       WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
+      WRITE( fmtstr, '(A,I0,A)' ) '(I4,', Pos%nTheta, 'G16.10)'
+      WRITE( ARRFile, fmtstr    ) Pos%nTheta, Pos%theta( 1:Pos%nTheta )
 # endif /* IHOP_THREED */
 
-       FLUSH( ARRFile )
+      FLUSH( ARRFile )
 #endif /* IHOP_WRITE_OUT */
 
     CASE DEFAULT
-       atten = 0.0
+      atten = 0.0
 
-       ! following to set PlotType has alread been done in READIN if that was
-       ! used for input
-       SELECT CASE ( Beam%RunType( 5:5 ) )
-       CASE ( 'R' )
-          PlotType = 'rectilin  '
-       CASE ( 'I' )
-          PlotType = 'irregular '
-       CASE DEFAULT
-          PlotType = 'rectilin  '
-       END SELECT
+      ! following to set PlotType has alread been done in READIN if that was
+      ! used for input
+      SELECT CASE ( Beam%RunType( 5:5 ) )
+      CASE ( 'R' )
+         PlotType = 'rectilin  '
+      CASE ( 'I' )
+         PlotType = 'irregular '
+      CASE DEFAULT
+         PlotType = 'rectilin  '
+      END SELECT
 
-       CALL WriteSHDHeader( TRIM( fullName ) // '.shd', Title, &
-                            REAL( IHOP_freq ), atten, PlotType )
+      CALL WriteSHDHeader( TRIM( fullName ) // '.shd', Title, &
+                           REAL( IHOP_freq ), atten, PlotType )
     END SELECT
 
   RETURN

--- a/src/ihop_init_diag.F90
+++ b/src/ihop_init_diag.F90
@@ -8,7 +8,6 @@ MODULE IHOP_INIT_DIAG
 
   ! mbp 12/2018, based on much older subroutine
 
-  USE ssp_mod,   only: SSP
   USE bdry_mod,  only: Bdry, HSInfo
   USE atten_mod, only: CRCI
 
@@ -45,7 +44,7 @@ CONTAINS
     USE angle_mod, only: Angles
     USE srpos_mod, only: WriteSxSy, WriteSzRz, WriteRcvrRanges, WriteFreqVec
 
-    ! I/O routine for acoustic fixed inputS
+  ! I/O routine for acoustic fixed inputS
 
   ! == Routine Arguments ==
   ! myTime  :: Current time in simulation
@@ -54,14 +53,11 @@ CONTAINS
   ! msgBuf  :: Used to build messages for printing.
     _RL, INTENT(IN)     ::  myTime
     INTEGER, INTENT(IN) ::  myIter, myThid
-    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+    CHARACTER*(MAX_LEN_MBUF) :: msgBuf
 
   ! == Local Variables ==
     INTEGER, PARAMETER :: Number_to_Echo = 10
-!    REAL (KIND=_RL90),  PARAMETER :: c0 = 1500.0
-!    REAL (KIND=_RL90)  :: x(2), c, cimag, gradc(2), crz, czz, rho, Depth
     REAL (KIND=_RL90)  :: ranges
-!    CHARACTER (LEN=10) :: PlotType
 
     ! *** ihop info to PRTFile ***
     CALL openPRTFile( myTime, myIter, myThid )
@@ -85,7 +81,7 @@ CONTAINS
       WRITE(msgBuf,'(2A)') 'Top options: ', Bdry%Top%HS%Opt
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
-      CALL writeBdry( Bdry%Top%HS, myThid )
+      CALL WriteBdry( Bdry%Top%HS, myThid )
 
       WRITE(msgBuf,'(A)')
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -100,7 +96,7 @@ CONTAINS
         CASE DEFAULT
       END SELECT
 
-      CALL writeBdry( Bdry%Bot%HS, myThid )
+      CALL WriteBdry( Bdry%Bot%HS, myThid )
 
       CALL WriteSxSy( myThid )
       CALL WriteSzRz( myThid )
@@ -1028,6 +1024,7 @@ CONTAINS
   !**********************************************************************!
 
   SUBROUTINE resetMemory()
+    USE ssp_mod,    only: SSP
     USE arr_mod,    only: nArr, Arr, U
     USE ihop_mod,   only: ray2D, MaxN, iStep
 

--- a/src/ihop_output.F
+++ b/src/ihop_output.F
@@ -4,6 +4,7 @@ C !INTERFACE:
       SUBROUTINE IHOP_OUTPUT( myTime, myIter, myThid )
 
 C !DESCRIPTION:
+C IESCO25: unused
 C calls subroutine that calculate diagnostic specific to IHOP
 
 C !USES:

--- a/src/refcoef.F90
+++ b/src/refcoef.F90
@@ -370,39 +370,35 @@ CONTAINS
   _BEGIN_MASTER(myThid)
 
 #ifdef IHOP_WRITE_OUT
-  ! In adjoint mode we do not write output besides on the first run
-  IF (IHOP_dumpfreq.GE.0) THEN
+  IF ( BotRC == 'F' ) THEN
+    WRITE( PRTFile,'(2A)' ) '_______________________________________', &
+                            '___________________________________'
+    WRITE( PRTFile,'(A)' )
+    WRITE( PRTFile,'(A)' ) 'Using tabulated bottom reflection coef.'
+    WRITE( PRTFile,'(2A)' ) 'BRCFile=', TRIM( IHOP_fileroot )//'.brc'
 
-    IF ( BotRC == 'F' ) THEN
-      WRITE( PRTFile,'(2A)' ) '_______________________________________', &
-                              '___________________________________'
-      WRITE( PRTFile,'(A)' )
-      WRITE( PRTFile,'(A)' ) 'Using tabulated bottom reflection coef.'
-      WRITE( PRTFile,'(2A)' ) 'BRCFile=', TRIM( IHOP_fileroot )//'.brc'
+    WRITE( PRTFile,'(2A,I10)' ) 'Number of points in bottom reflection ', &
+                         'coefficient = ', NBotPts
+  END IF
 
-      WRITE( PRTFile,'(2A,I10)' ) 'Number of points in bottom reflection ', &
-                           'coefficient = ', NBotPts
-    END IF
+  IF ( TopRC == 'F' ) THEN
+    WRITE( PRTFile,'(2A)' ) '_______________________________________', &
+                            '___________________________________'
+    WRITE( PRTFile,'(A)' )
+    WRITE( PRTFile,'(A)' ) 'Using tabulated top reflection coef.'
+    WRITE( PRTFile,'(2A)' ) 'TRCFile=', TRIM( IHOP_fileroot )//'.trc'
 
-    IF ( TopRC == 'F' ) THEN
-      WRITE( PRTFile,'(2A)' ) '_______________________________________', &
-                              '___________________________________'
-      WRITE( PRTFile,'(A)' )
-      WRITE( PRTFile,'(A)' ) 'Using tabulated top reflection coef.'
-      WRITE( PRTFile,'(2A)' ) 'TRCFile=', TRIM( IHOP_fileroot )//'.trc'
+    WRITE( PRTFile,'(2A,I10)' ) 'Number of points in top reflection ', &
+                         'coefficient = ', NTopPts
+  END IF
 
-      WRITE( PRTFile,'(2A,I10)' ) 'Number of points in top reflection ', &
-                           'coefficient = ', NTopPts
-    END IF
-
-    IF ( BotRC == 'P' ) THEN
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) 'Number of points in internal reflection ', &
-                          'coefficient = ', NkTab
-    END IF
-
-  END IF ! don't write in adjoint mode
+  IF ( BotRC == 'P' ) THEN
+    WRITE( PRTFile, * )
+    WRITE( PRTFile, * ) 'Number of points in internal reflection ', &
+                        'coefficient = ', NkTab
+  END IF
 #endif /* IHOP_WRITE_OUT */
+
   ! I/O on main thread only
   _END_MASTER(myThid)
   _BARRIER

--- a/src/ssp_mod.F90
+++ b/src/ssp_mod.F90
@@ -152,9 +152,7 @@ CONTAINS
     cCoef = (-1.,-1.)
 
     ! Extract gcm SSP field
-    IF ( .not. useSSPFile ) THEN
-      CALL gcmSSP( myThid )
-    ENDIF
+    IF ( .NOT.useSSPFile ) CALL gcmSSP( myThid )
 
     ! Write to PRTFile
     IF ( .NOT.usingMPI ) THEN
@@ -172,51 +170,51 @@ CONTAINS
     ! Populate rest of SSP derived type based on SSP interpolation scheme
     SELECT CASE ( SSP%Type )
     CASE ( 'N' )  !  N2-linear profile option
-       n2( 1:SSP%nPts ) = 1.0 / SSP%c( 1:SSP%nPts )**2
-       !IEsco23 Test this: n2(  1:SSP%nZ ) = 1.0 / SSP%c( 1:SSP%nZ )**2
+      n2( 1:SSP%nPts ) = 1.0 / SSP%c( 1:SSP%nPts )**2
+      !IEsco23 Test this: n2(  1:SSP%nZ ) = 1.0 / SSP%c( 1:SSP%nZ )**2
 
-       ! compute gradient, n2z
-       DO iz = 2, SSP%nPts
-          n2z( iz-1 ) = (  n2(   iz ) - n2(    iz-1 ) ) / &
-                        ( SSP%Z( iz ) - SSP%Z( iz-1 ) )
-       END DO
+      ! compute gradient, n2z
+      DO iz = 2, SSP%nPts
+        n2z( iz-1 ) = (  n2(   iz ) - n2(    iz-1 ) ) / &
+                      ( SSP%Z( iz ) - SSP%Z( iz-1 ) )
+      END DO
 
     CASE ( 'C' )  !  C-linear profile option
     CASE ( 'P' )  !  monotone PCHIP ACS profile option
-       !                                                               2      3
-       ! compute coefficients of std cubic polynomial: c0 + c1*x + c2*x + c3*x
-       !
-       CALL PCHIP( SSP%Z, SSP%c, SSP%nPts, cCoef, cSpln )
+      !                                                               2      3
+      ! compute coefficients of std cubic polynomial: c0 + c1*x + c2*x + c3*x
+      !
+      CALL PCHIP( SSP%Z, SSP%c, SSP%nPts, cCoef, cSpln )
 !IEsco23 Test this:
-!       CALL PCHIP( SSP%Z, SSP%c, SSP%nZ, cCoef, cSpln )
+!     CALL PCHIP( SSP%Z, SSP%c, SSP%nZ, cCoef, cSpln )
 
     CASE ( 'S' )  !  Cubic spline profile option
-       cSpln( 1, 1:SSP%nPts ) = SSP%c( 1:SSP%nPts )
+      cSpln( 1, 1:SSP%nPts ) = SSP%c( 1:SSP%nPts )
 !IEsco23 Test this:
-!       cSpln( 1, 1 : SSP%nZ ) = SSP%c( 1 : SSP%nZ )
+!     cSpln( 1, 1 : SSP%nZ ) = SSP%c( 1 : SSP%nZ )
 
-       ! Compute spline coefs
-       CALL cSpline( SSP%Z, cSpln( 1, 1 ), SSP%nPts, 0, 0, SSP%nPts )
+      ! Compute spline coefs
+      CALL cSpline( SSP%Z, cSpln( 1, 1 ), SSP%nPts, 0, 0, SSP%nPts )
 !IEsco23 Test this:
-!      CALL CSpline( SSP%Z, cSpln( 1,1 ), SSP%nZ,iBCBeg, iBCEnd, SSP%nZ )
+!     CALL CSpline( SSP%Z, cSpln( 1,1 ), SSP%nZ,iBCBeg, iBCEnd, SSP%nZ )
 
     CASE ( 'Q' )
-       ! calculate cz
-       DO ir = 1, SSP%nR
-         DO iz = 2, SSP%nZ
-           ! delta_z = ( SSP%Z( iz2 ) - SSP%Z( iz2-1 ) )
-           SSP%czMat( iz-1, ir ) = ( SSP%cMat( iz,   ir ) - &
-                                     SSP%cMat( iz-1, ir ) ) / &
-                                   ( SSP%Z( iz ) - SSP%Z( iz-1 ) )
-         END DO
-       END DO
+      ! calculate cz
+      DO ir = 1, SSP%nR
+        DO iz = 2, SSP%nZ
+          ! delta_z = ( SSP%Z( iz2 ) - SSP%Z( iz2-1 ) )
+          SSP%czMat( iz-1, ir ) = ( SSP%cMat( iz,   ir ) - &
+                                    SSP%cMat( iz-1, ir ) ) / &
+                                  ( SSP%Z( iz ) - SSP%Z( iz-1 ) )
+        END DO
+      END DO
 
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(A)') 'SSPMOD setSSP: Invalid SSP profile option'
-        CALL PRINT_ERROR( msgBuf,myThid )
+      WRITE(msgBuf,'(A)') 'SSPMOD setSSP: Invalid SSP profile option'
+      CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-        STOP 'ABNORMAL END: S/R setSSP'
+      STOP 'ABNORMAL END: S/R setSSP'
     END SELECT
 
   RETURN
@@ -1009,9 +1007,6 @@ SUBROUTINE gcmSSP( myThid )
     END DO
   END DO
 
-!IESCO c68s: IF ((nPx.GT.1) .OR. (nPy.GT.1)) THEN
-!IESCO c68s:   CALL GLOBAL_VEC_SUM_R8(SSP%nZ*SSP%nR,SSP%nZ*SSP%nR,tileSSP,myThid)
-!IESCO c68s: ENDIF
   CALL GLOBAL_SUM_VECTOR_RL(SSP%nZ*SSP%nR,tmpSSP,globSSP,myThid)
 
   ! reshape ssp to matrix
@@ -1022,7 +1017,6 @@ SUBROUTINE gcmSSP( myThid )
       k = k + 1
     END DO
   END DO
-! IESCO24: END MITgcm checkpoint69a uses a new global sum subroutine...
 
   IF(ALLOCATED(tileSSP)) DEALLOCATE(tileSSP)
   IF(ALLOCATED(tmpSSP))  DEALLOCATE(tmpSSP)


### PR DESCRIPTION
## New 
IO writing for `ARRFile`, `RAYFile`, and `DELFile` in MPI runs. All `pkg/ihop` IO is don't on a single process ID, regardless of how the MITgcm IO is handled. 

## Previous
Multiple processes on the same file unit number! Caused overwriting from processes that may not have been initiated outside of `myProcId.eq.0`


